### PR TITLE
feat: enable global keepalive with Turnstile widget support

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -12,7 +12,7 @@ initialize();
 <template>
   <div>
     <NuxtLayout>
-      <NuxtPage />
+      <NuxtPage keepalive />
     </NuxtLayout>
     <div id="modals" />
   </div>

--- a/components/TeamBuilder/TeamBuilderForm.vue
+++ b/components/TeamBuilder/TeamBuilderForm.vue
@@ -31,6 +31,17 @@ const turnstileToken = computed({
   },
 });
 
+// Template ref for Turnstile widget
+const turnstileRef = ref();
+
+// Handle keepalive restoration for Turnstile widget
+onActivated(() => {
+  // Reset Turnstile widget when component is restored from cache
+  nextTick(() => {
+    turnstileRef.value?.reset();
+  });
+});
+
 // Use props instead of composable
 const { isExistingDraftedTeam } = toRefs(props);
 
@@ -237,6 +248,7 @@ const handleTeamSubmit = async () => {
       </div>
     </Message>
     <NuxtTurnstile
+      ref="turnstileRef"
       v-model="turnstileToken"
       class="mx-auto"
     />


### PR DESCRIPTION
- Enable keepalive for all pages to preserve user state during navigation
- Add onActivated hook to reset Turnstile widget when returning from cache
- Improves team builder UX by preserving form data and player selections
- Maintains security by ensuring fresh Turnstile tokens on page restoration