### PR TITLE
fix: configure Nitro to inline resend package for build compatibility

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -116,6 +116,12 @@ export default defineNuxtConfig({
 
   compatibilityDate: '2024-12-17',
 
+  nitro: {
+    externals: {
+      inline: ['resend'],
+    },
+  },
+
   hotjar: {
     hotjarId: 5090647,
   },


### PR DESCRIPTION
## Summary
Fix build error caused by resend package dependency resolution in Nitro.

The resend package v6.1.1 has a dependency on `@react-email/render` which is not available in the Nitro build environment. By inlining the resend package in Nitro's externals configuration, we ensure it resolves its dependencies properly at runtime rather than at build time.

## Test plan
- [x] Build completes successfully (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] TypeScript strict mode validation passes (`pnpm typecheck`)
- [x] Email API endpoints remain functional