### PR TITLE
maintenance: secure local dev database workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
-# Supabase Configuration
-SUPABASE_URL="https://your-project.supabase.co"
-SUPABASE_KEY="your_anon_public_key_here"
-SUPABASE_SERVICE_ROLE_KEY="your_service_role_key_here"
+# Local Supabase Configuration (from `supabase start` output)
+SUPABASE_URL="http://127.0.0.1:54321"
+SUPABASE_KEY="your_local_anon_key_from_supabase_start"
+SUPABASE_SERVICE_ROLE_KEY="your_local_service_role_key_from_supabase_start"
 
 # Email Configuration
 RESEND_API_KEY="re_your_resend_api_key_here"
@@ -13,3 +13,11 @@ SYNC_API_KEY="your_secure_api_key_for_player_sync"
 # Application Configuration
 SITE_URL="http://localhost:3000"
 ACTIVE_SEASON="25-26"
+
+# Cloudflare Turnstile (testing keys shown - always pass)
+TURNSTILE_SITE_KEY="1x00000000000000000000AA"
+TURNSTILE_SECRET_KEY="1x0000000000000000000000000000000AA"
+
+# IMPORTANT: No production or remote database credentials should ever be added here.
+# Production credentials are managed exclusively via GitHub Secrets and CI/CD.
+# See scripts/README.md for data restoration workflows.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ node-compile-cache/
 .cache
 .output
 .env
+.env.*
+!.env.example
 dist
 
 # Working docs and private directories

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@ Project-specific guidance for **League of Our Own** - a Nuxt fantasy football we
 
 > **For general development practices** (TDD, TypeScript guidelines, code style, testing philosophy), see `~/.claude/CLAUDE.md` and the linked documentation.
 
+## Git Rules
+
+- **Always get explicit user approval before committing.** Show the proposed commit message and files to be committed, then wait for confirmation before running `git commit`.
+
 ## Database Safety Rules
 
 ### Absolute Rules (zero exceptions)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,54 @@ Project-specific guidance for **League of Our Own** - a Nuxt fantasy football we
 
 > **For general development practices** (TDD, TypeScript guidelines, code style, testing philosophy), see `~/.claude/CLAUDE.md` and the linked documentation.
 
+## Database Safety Rules
+
+### Absolute Rules (zero exceptions)
+
+1. **Never write to production from a local environment.**
+   No CLI command, script, migration, or query may target the production database. Production schema changes happen exclusively via the CI/CD pipeline (`supabase db push` in GitHub Actions).
+
+2. **Never store production credentials locally.**
+   No production database URL, password, connection string, or project ID may exist in any file in this project. The `.env` file contains **only local Supabase credentials** (127.0.0.1). Production and staging credentials are managed exclusively via GitHub Secrets.
+
+3. **Never run `supabase` CLI commands that target remote databases.**
+   Do not run `supabase link`, `supabase db push`, `supabase db pull`, or any CLI subcommand that connects to a remote database. If a Supabase CLI command is needed, tell the user what to run and let them execute it. The only safe local commands are `supabase start`, `supabase stop`, `supabase db reset`, `supabase migration new`, and `supabase gen types --local`.
+
+4. **Never run write operations against any remote database.**
+   This includes INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE, or any other mutating SQL against production or staging. The restore scripts in `scripts/` are the only approved mechanism for writing to staging, and they include safety checks to prevent targeting production.
+
+### Schema Change Workflow
+
+All schema changes follow this exact flow:
+
+1. Create migration locally: `npx supabase migration new <name>`
+2. Write SQL in `supabase/migrations/<timestamp>_<name>.sql`
+3. Test locally: `supabase db reset` (applies migrations + seed to local Docker instance)
+4. Commit migration file and push to branch
+5. CI validates migrations apply cleanly (`supabase db start`)
+6. Merge to `staging` branch triggers CI/CD to apply migrations to staging
+7. Merge to `main` branch triggers CI/CD to apply migrations to production
+
+### Data Restore Scripts
+
+Three bash scripts exist in `scripts/` for data restoration. All are **read-only against production** (dump only). All require credentials as CLI arguments (never stored in files).
+
+| Script | Purpose | Writes to |
+|--------|---------|-----------|
+| `db-restore-local.sh` | Pull live data into local Supabase Docker instance | Local only (127.0.0.1) |
+| `db-restore-staging.sh` | Refresh existing staging environment from live | Staging only |
+| `db-rebuild-staging.sh` | Full rebuild of new staging from live (migrations + data) | Staging only |
+
+Run `./scripts/<script>.sh --help` for usage details.
+
+### What CI/CD Handles (never local)
+
+- `supabase db push` to production (`.github/workflows/deploy-production.yml`)
+- `supabase db push` to staging (`.github/workflows/deploy-staging.yml`)
+- Migration validation via `supabase db start` (`.github/workflows/ci.yml`)
+
+---
+
 ## Quick Reference
 
 **Key Commands**:

--- a/docs/guides/database-restore.md
+++ b/docs/guides/database-restore.md
@@ -1,214 +1,117 @@
-# Database Restoration Guide: Live to Development
+# Database Restoration Guide
 
-This guide documents the proven method for safely restoring live database data to development database when network connectivity issues prevent direct database connections.
+This guide covers the three data restoration workflows for the project. All workflows are **read-only against production** — only dump operations are performed against the live database.
 
-## Problem Statement
+For full script documentation, see `scripts/README.md`.
 
-**WSL2 IPv6 Connectivity Issues**: Direct psql connections to remote Supabase databases fail in Windows Subsystem for Linux 2 (WSL2) environments due to IPv6 network configuration problems.
+## Prerequisites
 
-**Specific Error**:
-```bash
-psql: error: connection to server at "db.YOUR_DEV_PROJECT_ID.supabase.co" (2a05:d01c:30c:9d03:c0f7:5424:becb:f4d0), port 5432 failed: Network is unreachable
-```
+- **psql** installed (PostgreSQL client tools) — verify with `psql --version`
+- **Supabase CLI** installed (included as dev dependency — `pnpm install`)
+- **Supabase personal access token** — generate at https://supabase.com/dashboard/account/tokens
+- **Production project ID** — available from the Supabase dashboard
 
-**Root Cause**: WSL2's virtualized networking layer attempts IPv6 connections first, but the IPv6 stack is not properly configured, causing "Network is unreachable" errors. The system tries to connect via IPv6 addresses that aren't accessible from the WSL2 environment.
+## Workflow 1: Restore Live Data to Local
 
-**Failed Solutions Attempted**:
-- Direct psql connections (IPv6 timeout)
-- `npx supabase db reset --db-url` (same IPv6 issue)
-- DNS resolution works but returns unreachable IPv6 addresses
-- Installing Windows PostgreSQL tools in WSL2 not feasible
+Pull production data into your local Supabase Docker instance for development.
 
-## Solution: SQL Editor Method
+**When to use:** Setting up a local dev environment with realistic data.
 
-Use Supabase's web-based SQL Editor to execute split SQL files, bypassing all network connectivity issues.
-
-### Prerequisites
-
-1. **Live database dump** in `supabase/seed.sql` (generated via `npx supabase db dump --linked --data-only`)
-2. **Development database** access via Supabase web dashboard
-3. **Working directory**: Create `temp/` folder for split files
-
-### Step 1: Split the Database Dump
-
-Split the large seed.sql file into manageable chunks for SQL Editor execution:
+**Prerequisites:** Local Supabase must be running (`supabase start`).
 
 ```bash
-# Create temporary directory
-mkdir temp/
-
-# Split by table sections (adjust line numbers based on your dump structure)
-sed -n '1,1969p' supabase/seed.sql > temp/part1_auth.sql
-sed -n '1970,2707p' supabase/seed.sql > temp/part2_auth_users.sql
-sed -n '2708,3529p' supabase/seed.sql > temp/part3_teams_players.sql
-sed -n '3530,4441p' supabase/seed.sql > temp/part4_drafted_data.sql
-sed -n '4442,5032p' supabase/seed.sql > temp/part5_statistics.sql
+./scripts/db-restore-local.sh \
+  --project-id YOUR_PROD_PROJECT_ID \
+  --access-token YOUR_SUPABASE_ACCESS_TOKEN
 ```
 
-**Key Split Points** (find these in your dump):
-- Line ~25: `INSERT INTO "auth"."audit_log_entries"`
-- Line ~1970: `INSERT INTO "auth"."users"`
-- Line ~2708: `INSERT INTO "public"."drafted_teams"`
-- Line ~3530: `INSERT INTO "public"."drafted_players"`
-- Line ~4442: `INSERT INTO "public"."player_statistics"`
+If you already have a recent dump (`supabase/seed.sql`):
 
-### Step 2: Create Clear Script
-
-Create `temp/clear.sql` to safely remove existing data:
-
-```sql
--- CLEAR SCRIPT: Run this FIRST to clear all existing data in dev database
-SET session_replication_role = replica;
-
--- Clear auth tables (in reverse dependency order)
-TRUNCATE TABLE auth.mfa_amr_claims CASCADE;
-TRUNCATE TABLE auth.refresh_tokens CASCADE;
-TRUNCATE TABLE auth.sessions CASCADE;
-TRUNCATE TABLE auth.users CASCADE;
-TRUNCATE TABLE auth.audit_log_entries CASCADE;
-
--- Clear public tables (in reverse dependency order)
-TRUNCATE TABLE public.weekly_statistics CASCADE;
-TRUNCATE TABLE public.player_statistics CASCADE;
-TRUNCATE TABLE public.drafted_transfers CASCADE;
-TRUNCATE TABLE public.drafted_players CASCADE;
-TRUNCATE TABLE public.profiles CASCADE;
-TRUNCATE TABLE public.fixtures CASCADE;
-TRUNCATE TABLE public.players CASCADE;
-TRUNCATE TABLE public.teams CASCADE;
-TRUNCATE TABLE public.drafted_teams CASCADE;
-
--- Reset sequences (only public schema - auth sequences are protected)
-ALTER SEQUENCE public.drafted_players_id_seq RESTART WITH 1;
-ALTER SEQUENCE public.drafted_teams_team_id_seq RESTART WITH 1;
-ALTER SEQUENCE public.drafted_transfers_id_seq RESTART WITH 1;
-ALTER SEQUENCE public.fixtures_id_seq RESTART WITH 1;
-ALTER SEQUENCE public.player_statistics_id_seq RESTART WITH 1;
-ALTER SEQUENCE public.weekly_statistics_id_seq RESTART WITH 1;
-
--- Note: auth.refresh_tokens_id_seq cannot be reset due to permissions
-
-SET session_replication_role = DEFAULT;
-
--- Verification: Check that tables are empty
-SELECT 'auth.audit_log_entries' as table_name, count(*) as row_count FROM auth.audit_log_entries
-UNION ALL
-SELECT 'auth.users', count(*) FROM auth.users
-UNION ALL
-SELECT 'public.drafted_teams', count(*) FROM public.drafted_teams
-UNION ALL
-SELECT 'public.players', count(*) FROM public.players;
+```bash
+./scripts/db-restore-local.sh --skip-dump
 ```
 
-### Step 3: Add Headers to Part Files
+**What happens:**
+1. Dumps production data via Supabase management API (read-only, bypasses IPv6)
+2. Clears all local tables
+3. Restores dump via `psql` to `127.0.0.1:54322` (IPv4, no connectivity issues)
+4. Verifies row counts
 
-Add proper SQL headers to each part file:
+## Workflow 2: Refresh Staging from Live
 
-```sql
--- PART X: Description
-SET session_replication_role = replica;
+Refresh data on an existing staging environment. The staging project must already have migrations applied (via CI/CD — merge to the `staging` branch).
 
--- (existing INSERT statements follow)
+**When to use:** Staging data is stale or corrupted and needs refreshing.
+
+```bash
+./scripts/db-restore-staging.sh \
+  --prod-project-id YOUR_PROD_PROJECT_ID \
+  --access-token YOUR_SUPABASE_ACCESS_TOKEN \
+  --staging-project-id YOUR_STAGING_PROJECT_ID \
+  --staging-db-password YOUR_STAGING_DB_PASSWORD
 ```
 
-### Step 4: Execute via SQL Editor
+**What happens:**
+1. Dumps production data (read-only)
+2. Safety check: verifies staging ID does not match production ID
+3. Connects to staging (pooler first, falls back to direct IPv4)
+4. Clears staging tables and restores dump
+5. Verifies row counts
 
-1. **Access Dev Database**: Go to development Supabase project → SQL Editor
+## Workflow 3: Full Staging Rebuild
 
-2. **Pre-Execution Check**: Before running part5, search the file for the storage.buckets section and **remove it** to avoid duplicate key errors (see "Storage Bucket Duplicate Key Errors" in Common Issues section)
+Full rebuild when the staging Supabase project has been deleted and recreated (e.g. after a 90-day free-tier pause).
 
-3. **Execute in Order**:
-   - `clear.sql` (verify tables show 0 rows)
-   - `part1_auth_audit.sql`
-   - `part2_auth_users.sql`
-   - `part3_teams_players.sql`
-   - `part4_drafted_data.sql`
-   - `part5_profiles_fixtures_stats.sql` ⚠️ (after removing storage.buckets INSERT)
-   - `part6_sequences.sql`
+**When to use:** New staging project with no schema or data.
 
-### Step 5: Verify Success
-
-Run verification query in SQL Editor:
-
-```sql
-SELECT
-    'auth.users' as table_name, count(*) as rows FROM auth.users
-UNION ALL
-SELECT 'public.drafted_teams', count(*) FROM public.drafted_teams
-UNION ALL
-SELECT 'public.players', count(*) FROM public.players
-UNION ALL
-SELECT 'public.fixtures', count(*) FROM public.fixtures
-UNION ALL
-SELECT 'public.player_statistics', count(*) FROM public.player_statistics
-ORDER BY table_name;
+```bash
+./scripts/db-rebuild-staging.sh \
+  --prod-project-id YOUR_PROD_PROJECT_ID \
+  --access-token YOUR_SUPABASE_ACCESS_TOKEN \
+  --staging-project-id YOUR_STAGING_PROJECT_ID \
+  --staging-db-password YOUR_STAGING_DB_PASSWORD
 ```
 
-## Common Issues and Solutions
+**What happens:**
+1. Dumps production data (read-only)
+2. Temporarily links Supabase CLI to staging (never production)
+3. Applies all migrations via `supabase db push`
+4. Unlinks CLI from staging (cleans up `.temp` files)
+5. Clears staging tables and restores dump
+6. Verifies row counts
 
-### Permission Errors on Sequences
+**After rebuild, update GitHub Secrets:**
+- `STAGING_PROJECT_ID` — new staging project ID
+- `STAGING_DB_PASSWORD` — new staging database password
 
-**Error**: `must be owner of sequence refresh_tokens_id_seq`
+## WSL2 / IPv6 Connectivity
 
-**Solution**: Skip auth schema sequence resets - they're protected by Supabase. Only reset public schema sequences.
+All three scripts handle the IPv6 connectivity issues common in WSL2 environments:
 
-### SQL Editor Timeouts
+| Operation | Connection method | IPv6 issue? |
+|-----------|------------------|-------------|
+| Production dump | Supabase management API | No |
+| Local restore | `psql` to `127.0.0.1` (IPv4) | No |
+| Staging write | Connection pooler, fallback to direct IPv4 | Handled |
 
-**Solution**: Split large files further if needed. Most files under 1000 lines execute successfully.
+### Manual Fallback (SQL Editor)
 
-### IPv6 Network Issues
+If staging connectivity fails completely from WSL2, you can restore data manually via the Supabase SQL Editor:
 
-**Solution**: This method completely bypasses network connectivity by using the web interface.
-
-### Storage Bucket Duplicate Key Errors
-
-**Error**: `ERROR: 23505: duplicate key value violates unique constraint "buckets_pkey" DETAIL: Key (id)=(avatars) already exists.`
-
-**Root Cause**: The `storage.buckets` table in your dev database already contains infrastructure buckets (like 'avatars') that were created during initial Supabase project setup. The seed.sql dump includes these buckets, causing conflicts when restoring.
-
-**Solution**: Remove the storage bucket INSERT statements from the restoration files before execution:
-
-1. **Locate the storage section** in your part file containing statistics data (typically part5):
-   ```sql
-   --
-   -- Data for Name: buckets; Type: TABLE DATA; Schema: storage; Owner: supabase_storage_admin
-   --
-
-   INSERT INTO "storage"."buckets" ("id", "name", "owner", "created_at", "updated_at", "public", "avif_autodetection", "file_size_limit", "allowed_mime_types", "owner_id", "type") VALUES
-   	('avatars', 'avatars', NULL, '2023-07-30 17:46:08.561788+00', '2023-07-30 17:46:08.561788+00', false, false, NULL, NULL, NULL, 'STANDARD');
-   ```
-
-2. **Delete these lines entirely** - from the comment block through the INSERT statement and blank lines
-
-3. **Keep the footer**: Make sure `SET session_replication_role = DEFAULT;` remains at the end of the file
-
-**Why this is safe**: Storage buckets are infrastructure that persist across environments. They don't need to be restored from live database dumps - your dev database buckets are appropriate for development.
-
-## File Organization
-
-```
-temp/
-├── clear.sql                          # Data clearing script (42 lines)
-├── part1_auth_audit.sql               # Auth audit logs (2,459 lines)
-├── part2_auth_users.sql               # Users, sessions & tokens (1,046 lines)
-├── part3_teams_players.sql            # Teams & players (842 lines)
-├── part4_drafted_data.sql             # Drafted players & transfers (543 lines)
-├── part5_profiles_fixtures_stats.sql  # Profiles, fixtures & statistics (1,681 lines)
-│   └── ⚠️ Remove storage.buckets INSERT before execution
-├── part6_sequences.sql                # Sequence resets (62 lines)
-├── README.md                          # File documentation
-└── EXECUTION_GUIDE.md                 # Step-by-step instructions
-```
+1. Generate the dump: `./scripts/db-restore-local.sh` creates `supabase/seed.sql`
+2. Split the file into chunks: `mkdir temp && sed -n '1,2000p' supabase/seed.sql > temp/part1.sql` (etc.)
+3. Execute each chunk via the staging project's SQL Editor in the Supabase dashboard
+4. See the original detailed guide in git history for specific split points and troubleshooting
 
 ## Safety Guarantees
 
-✅ **Live database never modified** - only read from during dump creation
-✅ **Development database clearly targeted** - different hostnames prevent confusion
-✅ **Reversible operations** - can clear and restore again anytime
-✅ **Network-independent** - uses web interface instead of direct connections
+- Production database is **never modified** — read-only dump operations only
+- All scripts require **explicit typed confirmation** before proceeding
+- Staging scripts verify the staging project ID **does not match** production
+- **No credentials are stored** in any file — all provided as CLI arguments
+- Scripts clean up temporary CLI links after use
+- `.gitignore` blocks all `.env` variants (except `.env.example`)
 
 ---
 
-**Last Updated**: September 2025
-**Verified Working**: Supabase projects with 5000+ line database dumps
-**Environment**: WSL2 with IPv6 connectivity issues
+**Last Updated**: March 2026

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
-    "generate-types": "npx supabase gen types typescript --project-id jcjsymrofqoppfuacfqv > types/database-generated.types.ts",
-    "generate-types:local": "npx supabase gen types typescript --local > types/database-generated.types.ts"
+    "generate-types": "npx supabase gen types typescript --local > types/database-generated.types.ts",
+    "db:restore-local": "./scripts/db-restore-local.sh",
+    "db:restore-staging": "./scripts/db-restore-staging.sh",
+    "db:rebuild-staging": "./scripts/db-rebuild-staging.sh"
   },
   "dependencies": {
     "@primeuix/themes": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
-    "generate-types": "npx supabase gen types typescript --local > types/database-generated.types.ts",
-    "db:restore-local": "./scripts/db-restore-local.sh",
-    "db:restore-staging": "./scripts/db-restore-staging.sh",
-    "db:rebuild-staging": "./scripts/db-rebuild-staging.sh"
+    "generate-types": "npx supabase gen types typescript --local > types/database-generated.types.ts"
   },
   "dependencies": {
     "@primeuix/themes": "^1.2.3",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,70 @@
+# Database Restore Scripts
+
+Scripts for safely restoring data across environments. All scripts are **read-only against production** -- they only perform `pg_dump`/`supabase db dump` operations against the live database.
+
+## Prerequisites
+
+- Local Supabase running (`supabase start`) for local restores
+- `psql` installed (PostgreSQL client tools)
+- Supabase CLI installed (`pnpm install` includes it)
+- Supabase personal access token (generate at https://supabase.com/dashboard/account/tokens)
+
+## Scripts
+
+### 1. Restore to Local (`db-restore-local.sh`)
+
+Pull live data into your local Supabase Docker instance for development.
+
+```bash
+./scripts/db-restore-local.sh \
+  --project-id YOUR_PROD_PROJECT_ID \
+  --access-token YOUR_SUPABASE_ACCESS_TOKEN
+```
+
+If you already have a dump file (`supabase/seed.sql`), skip the dump step:
+
+```bash
+./scripts/db-restore-local.sh --skip-dump
+```
+
+### 2. Restore to Staging (`db-restore-staging.sh`)
+
+Refresh data on an existing staging environment from live. Staging must already have migrations applied (via CI/CD).
+
+```bash
+./scripts/db-restore-staging.sh \
+  --prod-project-id YOUR_PROD_PROJECT_ID \
+  --access-token YOUR_SUPABASE_ACCESS_TOKEN \
+  --staging-project-id YOUR_STAGING_PROJECT_ID \
+  --staging-db-password YOUR_STAGING_DB_PASSWORD
+```
+
+### 3. Rebuild Staging (`db-rebuild-staging.sh`)
+
+Full rebuild when the staging Supabase project has been deleted and recreated (e.g. after a 90-day pause). Applies migrations first, then restores data.
+
+```bash
+./scripts/db-rebuild-staging.sh \
+  --prod-project-id YOUR_PROD_PROJECT_ID \
+  --access-token YOUR_SUPABASE_ACCESS_TOKEN \
+  --staging-project-id YOUR_STAGING_PROJECT_ID \
+  --staging-db-password YOUR_STAGING_DB_PASSWORD
+```
+
+## Safety Guarantees
+
+- Production database is **never modified** -- only read via `supabase db dump`
+- All scripts require **explicit confirmation** before proceeding
+- Staging scripts verify the staging project ID does **not** match production
+- No credentials are stored in files -- all provided as CLI arguments at runtime
+- Scripts clean up any temporary Supabase CLI links after use
+
+## WSL2 Notes
+
+These scripts handle the IPv6 connectivity issues in WSL2 environments:
+
+- **Local restores** use `127.0.0.1` (IPv4) -- no issue
+- **Production dumps** use the Supabase management API -- no direct psql needed
+- **Staging writes** attempt the connection pooler first, then fall back to direct IPv4 resolution
+
+If staging connectivity fails completely, see `docs/guides/database-restore.md` for the manual SQL Editor fallback method.

--- a/scripts/db-rebuild-staging.sh
+++ b/scripts/db-rebuild-staging.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# db-rebuild-staging.sh
+#
+# Full rebuild of a staging environment from scratch. Use this when the staging
+# Supabase project has been deleted and recreated (e.g. after 90-day pause).
+#
+# This script:
+#   1. Dumps production data (read-only)
+#   2. Applies all migrations to the fresh staging project
+#   3. Restores production data into staging
+#
+# Production is NEVER written to.
+#
+# Usage:
+#   ./scripts/db-rebuild-staging.sh \
+#     --prod-project-id <PROD_ID> \
+#     --access-token <TOKEN> \
+#     --staging-project-id <STAGING_ID> \
+#     --staging-db-password <PASSWORD>
+#
+# Prerequisites:
+#   - psql installed
+#   - Supabase CLI installed (npx supabase)
+# =============================================================================
+
+DUMP_FILE="supabase/seed.sql"
+
+# -----------------------------------------------------------------------------
+# Colour helpers
+# -----------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC}  $*"; }
+success() { echo -e "${GREEN}[OK]${NC}    $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# -----------------------------------------------------------------------------
+# Usage
+# -----------------------------------------------------------------------------
+usage() {
+  cat <<EOF
+Usage: $0 --prod-project-id <ID> --access-token <TOKEN> --staging-project-id <ID> --staging-db-password <PASSWORD>
+
+Full rebuild of a staging environment from a fresh Supabase project.
+Applies all migrations, then restores production data.
+
+Options:
+  --prod-project-id       Production Supabase project ID (read-only dump)
+  --access-token          Supabase personal access token
+  --staging-project-id    Staging Supabase project ID (write target)
+  --staging-db-password   Staging database password
+  --skip-dump             Skip the dump step and use existing supabase/seed.sql
+  -h, --help              Show this help message
+EOF
+  exit 0
+}
+
+# -----------------------------------------------------------------------------
+# Parse arguments
+# -----------------------------------------------------------------------------
+PROD_PROJECT_ID=""
+ACCESS_TOKEN=""
+STAGING_PROJECT_ID=""
+STAGING_DB_PASSWORD=""
+SKIP_DUMP=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prod-project-id)      PROD_PROJECT_ID="$2"; shift 2 ;;
+    --access-token)         ACCESS_TOKEN="$2"; shift 2 ;;
+    --staging-project-id)   STAGING_PROJECT_ID="$2"; shift 2 ;;
+    --staging-db-password)  STAGING_DB_PASSWORD="$2"; shift 2 ;;
+    --skip-dump)            SKIP_DUMP=true; shift ;;
+    -h|--help)              usage ;;
+    *)                      error "Unknown option: $1"; usage ;;
+  esac
+done
+
+# Validate required arguments
+if [[ "$SKIP_DUMP" == false ]]; then
+  [[ -z "$PROD_PROJECT_ID" ]]   && { error "Missing: --prod-project-id"; usage; }
+  [[ -z "$ACCESS_TOKEN" ]]       && { error "Missing: --access-token"; usage; }
+fi
+[[ -z "$STAGING_PROJECT_ID" ]]    && { error "Missing: --staging-project-id"; usage; }
+[[ -z "$STAGING_DB_PASSWORD" ]]   && { error "Missing: --staging-db-password"; usage; }
+
+# Safety: ensure staging and production are different projects
+if [[ "$SKIP_DUMP" == false && "$STAGING_PROJECT_ID" == "$PROD_PROJECT_ID" ]]; then
+  error "SAFETY CHECK FAILED: Staging project ID matches production project ID!"
+  error "This script will NEVER write to production. Aborting."
+  exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Build staging connection URL
+# -----------------------------------------------------------------------------
+STAGING_HOST="db.${STAGING_PROJECT_ID}.supabase.co"
+STAGING_DB_URL="postgresql://postgres.${STAGING_PROJECT_ID}:${STAGING_DB_PASSWORD}@aws-0-eu-west-2.pooler.supabase.com:6543/postgres"
+
+# -----------------------------------------------------------------------------
+# Preflight checks
+# -----------------------------------------------------------------------------
+info "Running preflight checks..."
+
+if ! command -v psql &>/dev/null; then
+  error "psql is not installed. Install PostgreSQL client tools."
+  exit 1
+fi
+success "psql found: $(psql --version)"
+
+if ! npx supabase --version &>/dev/null; then
+  error "Supabase CLI not found. Run: pnpm install"
+  exit 1
+fi
+success "Supabase CLI found"
+
+# Check migrations directory exists
+if [[ ! -d "supabase/migrations" ]]; then
+  error "supabase/migrations directory not found. Are you in the project root?"
+  exit 1
+fi
+
+MIGRATION_COUNT=$(find supabase/migrations -name "*.sql" | wc -l)
+success "Found ${MIGRATION_COUNT} migration files"
+
+# Test staging connectivity
+info "Testing staging database connectivity..."
+if ! psql "$STAGING_DB_URL" -c "SELECT 1" &>/dev/null 2>&1; then
+  warn "Could not connect to staging via pooler. Trying direct connection..."
+  STAGING_IPV4=$(getent ahostsv4 "$STAGING_HOST" 2>/dev/null | head -1 | awk '{print $1}' || true)
+  if [[ -n "$STAGING_IPV4" ]]; then
+    STAGING_DB_URL="postgresql://postgres:${STAGING_DB_PASSWORD}@${STAGING_IPV4}:5432/postgres?sslmode=require"
+    if ! psql "$STAGING_DB_URL" -c "SELECT 1" &>/dev/null 2>&1; then
+      error "Cannot connect to staging database. Check credentials and network."
+      error "If in WSL2, you may need to run migrations via CI/CD and data via SQL Editor."
+      exit 1
+    fi
+    success "Connected to staging via direct IPv4 (${STAGING_IPV4})"
+  else
+    error "Cannot resolve staging host to IPv4. Check network connectivity."
+    exit 1
+  fi
+else
+  success "Connected to staging via connection pooler"
+fi
+
+# -----------------------------------------------------------------------------
+# Confirmation
+# -----------------------------------------------------------------------------
+echo ""
+echo "============================================="
+echo "  STAGING FULL REBUILD"
+echo "============================================="
+echo ""
+if [[ "$SKIP_DUMP" == false ]]; then
+  info "Source:      Production project ${PROD_PROJECT_ID} (READ-ONLY dump)"
+fi
+info "Destination: Staging project ${STAGING_PROJECT_ID} (FRESH rebuild)"
+info "Migrations:  ${MIGRATION_COUNT} files to apply"
+info "Dump file:   ${DUMP_FILE}"
+echo ""
+warn "This will:"
+warn "  1. Apply all migrations to the staging project"
+warn "  2. Clear any existing data in staging"
+warn "  3. Restore production data into staging"
+warn ""
+warn "Production will NOT be modified (read-only dump only)."
+echo ""
+
+read -rp "Type 'rebuild-staging' to confirm: " confirm
+if [[ "$confirm" != "rebuild-staging" ]]; then
+  info "Aborted."
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Step 1: Dump production data (read-only)
+# -----------------------------------------------------------------------------
+if [[ "$SKIP_DUMP" == false ]]; then
+  info "Dumping production data (read-only)..."
+  SUPABASE_ACCESS_TOKEN="$ACCESS_TOKEN" npx supabase db dump \
+    --project-ref "$PROD_PROJECT_ID" \
+    --data-only \
+    -f "$DUMP_FILE"
+  success "Production dump saved to ${DUMP_FILE}"
+else
+  if [[ ! -f "$DUMP_FILE" ]]; then
+    error "Dump file not found at ${DUMP_FILE}. Run without --skip-dump first."
+    exit 1
+  fi
+  info "Using existing dump file: ${DUMP_FILE}"
+fi
+
+# -----------------------------------------------------------------------------
+# Step 2: Apply migrations to staging
+# -----------------------------------------------------------------------------
+info "Linking to staging project for migration push..."
+
+# Temporarily link to staging (never production)
+SUPABASE_ACCESS_TOKEN="$ACCESS_TOKEN" npx supabase link \
+  --project-ref "$STAGING_PROJECT_ID" \
+  --password "$STAGING_DB_PASSWORD"
+
+success "Linked to staging project"
+
+info "Pushing migrations to staging..."
+SUPABASE_ACCESS_TOKEN="$ACCESS_TOKEN" SUPABASE_DB_PASSWORD="$STAGING_DB_PASSWORD" npx supabase db push
+
+success "Migrations applied to staging"
+
+# Clean up the temporary link
+rm -f supabase/.temp/project-ref supabase/.temp/pooler-url
+info "Unlinked from staging project (cleaned up .temp files)"
+
+# -----------------------------------------------------------------------------
+# Step 3: Clear staging database
+# -----------------------------------------------------------------------------
+info "Clearing staging database..."
+
+psql "$STAGING_DB_URL" <<'SQL'
+SET session_replication_role = replica;
+
+-- Clear public tables (reverse dependency order)
+TRUNCATE TABLE public.weekly_statistics CASCADE;
+TRUNCATE TABLE public.player_statistics CASCADE;
+TRUNCATE TABLE public.drafted_transfers CASCADE;
+TRUNCATE TABLE public.drafted_players CASCADE;
+TRUNCATE TABLE public.settings CASCADE;
+TRUNCATE TABLE public.profiles CASCADE;
+TRUNCATE TABLE public.fixtures CASCADE;
+TRUNCATE TABLE public.players CASCADE;
+TRUNCATE TABLE public.teams CASCADE;
+TRUNCATE TABLE public.drafted_teams CASCADE;
+
+-- Clear auth tables
+TRUNCATE TABLE auth.mfa_amr_claims CASCADE;
+TRUNCATE TABLE auth.refresh_tokens CASCADE;
+TRUNCATE TABLE auth.sessions CASCADE;
+TRUNCATE TABLE auth.users CASCADE;
+TRUNCATE TABLE auth.audit_log_entries CASCADE;
+
+-- Reset public sequences
+DO $$
+DECLARE
+  seq RECORD;
+BEGIN
+  FOR seq IN
+    SELECT sequencename FROM pg_sequences WHERE schemaname = 'public'
+  LOOP
+    EXECUTE format('ALTER SEQUENCE public.%I RESTART WITH 1', seq.sequencename);
+  END LOOP;
+END $$;
+
+SET session_replication_role = DEFAULT;
+SQL
+
+success "Staging database cleared"
+
+# -----------------------------------------------------------------------------
+# Step 4: Restore dump to staging
+# -----------------------------------------------------------------------------
+info "Restoring data to staging database..."
+
+# Filter the dump to remove sections that conflict with existing infrastructure:
+#   - storage.buckets (already exist in fresh Supabase instances)
+#   - storage.objects (references buckets, can cause FK issues)
+#   - storage.s3_multipart_uploads (infrastructure table)
+#   - Any ALTER SEQUENCE on auth schema (permission denied — Supabase owns these)
+FILTERED_DUMP=$(mktemp)
+sed \
+  -e '/^-- Data for Name: buckets; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/^-- Data for Name: objects; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/^-- Data for Name: s3_multipart_uploads; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/^-- Data for Name: s3_multipart_uploads_parts; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/INSERT INTO "storage"."buckets"/d' \
+  -e '/INSERT INTO "storage"."objects"/d' \
+  -e '/INSERT INTO "storage"."s3_multipart_uploads/d' \
+  -e '/ALTER SEQUENCE "auth"\./d' \
+  -e '/SELECT pg_catalog.setval.*auth\./d' \
+  "$DUMP_FILE" > "$FILTERED_DUMP"
+
+# Wrap restore in session_replication_role = replica so foreign key constraints
+# don't block INSERTs when rows arrive out of dependency order (which pg_dump
+# data-only dumps frequently produce).
+ERROR_LOG=$(mktemp)
+
+psql "$STAGING_DB_URL" --quiet \
+  -v ON_ERROR_STOP=0 \
+  -c "SET session_replication_role = replica;" \
+  -f "$FILTERED_DUMP" \
+  -c "SET session_replication_role = DEFAULT;" \
+  2>"$ERROR_LOG" | grep -v "^SET$" || true
+
+# Report any errors (but don't fail — some warnings are expected)
+if [[ -s "$ERROR_LOG" ]]; then
+  # Filter out known harmless warnings
+  REAL_ERRORS=$(grep -v -E "^(SET|COMMENT|$)" "$ERROR_LOG" | grep -i "error" || true)
+  if [[ -n "$REAL_ERRORS" ]]; then
+    warn "Some errors occurred during restore (review below):"
+    echo "$REAL_ERRORS" | head -20
+    echo ""
+    warn "Full error log: ${ERROR_LOG}"
+  else
+    rm -f "$ERROR_LOG"
+  fi
+else
+  rm -f "$ERROR_LOG"
+fi
+
+rm -f "$FILTERED_DUMP"
+success "Data restored to staging database"
+
+# -----------------------------------------------------------------------------
+# Step 5: Verify
+# -----------------------------------------------------------------------------
+info "Verifying restore..."
+
+psql "$STAGING_DB_URL" --tuples-only --no-align -c "
+  SELECT 'auth.users', count(*) FROM auth.users
+  UNION ALL SELECT 'public.teams', count(*) FROM public.teams
+  UNION ALL SELECT 'public.players', count(*) FROM public.players
+  UNION ALL SELECT 'public.drafted_teams', count(*) FROM public.drafted_teams
+  UNION ALL SELECT 'public.fixtures', count(*) FROM public.fixtures
+  UNION ALL SELECT 'public.player_statistics', count(*) FROM public.player_statistics
+  ORDER BY 1;
+" | while IFS='|' read -r table count; do
+  echo -e "  ${GREEN}${table}${NC}: ${count} rows"
+done
+
+echo ""
+success "Staging full rebuild complete!"
+echo ""
+info "Next steps:"
+info "  1. Update your staging .env with the new project URL and keys"
+info "  2. Configure GitHub Secrets for the new staging project:"
+info "     - STAGING_PROJECT_ID"
+info "     - STAGING_DB_PASSWORD"
+info "  3. Deploy your application to the staging environment"

--- a/scripts/db-rebuild-staging.sh
+++ b/scripts/db-rebuild-staging.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 # Usage:
 #   ./scripts/db-rebuild-staging.sh \
 #     --prod-project-id <PROD_ID> \
-#     --access-token <TOKEN> \
+#     --prod-db-password <PROD_DB_PASSWORD> \
 #     --staging-project-id <STAGING_ID> \
 #     --staging-db-password <PASSWORD>
 #
@@ -47,14 +47,14 @@ error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 # -----------------------------------------------------------------------------
 usage() {
   cat <<EOF
-Usage: $0 --prod-project-id <ID> --access-token <TOKEN> --staging-project-id <ID> --staging-db-password <PASSWORD>
+Usage: $0 --prod-project-id <ID> --prod-db-password <PASSWORD> --staging-project-id <ID> --staging-db-password <PASSWORD>
 
 Full rebuild of a staging environment from a fresh Supabase project.
 Applies all migrations, then restores production data.
 
 Options:
   --prod-project-id       Production Supabase project ID (read-only dump)
-  --access-token          Supabase personal access token
+  --prod-db-password      Production database password
   --staging-project-id    Staging Supabase project ID (write target)
   --staging-db-password   Staging database password
   --skip-dump             Skip the dump step and use existing supabase/seed.sql
@@ -67,7 +67,7 @@ EOF
 # Parse arguments
 # -----------------------------------------------------------------------------
 PROD_PROJECT_ID=""
-ACCESS_TOKEN=""
+PROD_DB_PASSWORD=""
 STAGING_PROJECT_ID=""
 STAGING_DB_PASSWORD=""
 SKIP_DUMP=false
@@ -75,7 +75,7 @@ SKIP_DUMP=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --prod-project-id)      PROD_PROJECT_ID="$2"; shift 2 ;;
-    --access-token)         ACCESS_TOKEN="$2"; shift 2 ;;
+    --prod-db-password)     PROD_DB_PASSWORD="$2"; shift 2 ;;
     --staging-project-id)   STAGING_PROJECT_ID="$2"; shift 2 ;;
     --staging-db-password)  STAGING_DB_PASSWORD="$2"; shift 2 ;;
     --skip-dump)            SKIP_DUMP=true; shift ;;
@@ -87,7 +87,7 @@ done
 # Validate required arguments
 if [[ "$SKIP_DUMP" == false ]]; then
   [[ -z "$PROD_PROJECT_ID" ]]   && { error "Missing: --prod-project-id"; usage; }
-  [[ -z "$ACCESS_TOKEN" ]]       && { error "Missing: --access-token"; usage; }
+  [[ -z "$PROD_DB_PASSWORD" ]]  && { error "Missing: --prod-db-password"; usage; }
 fi
 [[ -z "$STAGING_PROJECT_ID" ]]    && { error "Missing: --staging-project-id"; usage; }
 [[ -z "$STAGING_DB_PASSWORD" ]]   && { error "Missing: --staging-db-password"; usage; }
@@ -186,8 +186,9 @@ fi
 # -----------------------------------------------------------------------------
 if [[ "$SKIP_DUMP" == false ]]; then
   info "Dumping production data (read-only)..."
-  SUPABASE_ACCESS_TOKEN="$ACCESS_TOKEN" npx supabase db dump \
-    --project-ref "$PROD_PROJECT_ID" \
+  PROD_DB_URL="postgresql://postgres.${PROD_PROJECT_ID}:${PROD_DB_PASSWORD}@aws-0-eu-west-2.pooler.supabase.com:5432/postgres"
+  npx supabase db dump \
+    --db-url "$PROD_DB_URL" \
     --data-only \
     -f "$DUMP_FILE"
   success "Production dump saved to ${DUMP_FILE}"
@@ -205,14 +206,14 @@ fi
 info "Linking to staging project for migration push..."
 
 # Temporarily link to staging (never production)
-SUPABASE_ACCESS_TOKEN="$ACCESS_TOKEN" npx supabase link \
+npx supabase link \
   --project-ref "$STAGING_PROJECT_ID" \
   --password "$STAGING_DB_PASSWORD"
 
 success "Linked to staging project"
 
 info "Pushing migrations to staging..."
-SUPABASE_ACCESS_TOKEN="$ACCESS_TOKEN" SUPABASE_DB_PASSWORD="$STAGING_DB_PASSWORD" npx supabase db push
+SUPABASE_DB_PASSWORD="$STAGING_DB_PASSWORD" npx supabase db push
 
 success "Migrations applied to staging"
 

--- a/scripts/db-restore-local.sh
+++ b/scripts/db-restore-local.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Docker instance. Production is never written to.
 #
 # Usage:
-#   ./scripts/db-restore-local.sh --project-id <PROD_PROJECT_ID> --access-token <SUPABASE_ACCESS_TOKEN>
+#   ./scripts/db-restore-local.sh --project-id <PROD_PROJECT_ID> --db-password <PROD_DB_PASSWORD>
 #
 # Prerequisites:
 #   - Local Supabase running (supabase start)
@@ -38,13 +38,13 @@ error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 # -----------------------------------------------------------------------------
 usage() {
   cat <<EOF
-Usage: $0 --project-id <PROD_PROJECT_ID> --access-token <SUPABASE_ACCESS_TOKEN>
+Usage: $0 --project-id <PROD_PROJECT_ID> --db-password <PROD_DB_PASSWORD>
 
 Dumps production data (read-only) and restores it into the local Supabase instance.
 
 Options:
   --project-id     Production Supabase project ID (read-only dump)
-  --access-token   Supabase personal access token
+  --db-password    Production database password
   --skip-dump      Skip the dump step and use existing supabase/seed.sql
   -h, --help       Show this help message
 EOF
@@ -55,13 +55,13 @@ EOF
 # Parse arguments
 # -----------------------------------------------------------------------------
 PROJECT_ID=""
-ACCESS_TOKEN=""
+PROD_DB_PASSWORD=""
 SKIP_DUMP=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project-id)     PROJECT_ID="$2"; shift 2 ;;
-    --access-token)   ACCESS_TOKEN="$2"; shift 2 ;;
+    --db-password)    PROD_DB_PASSWORD="$2"; shift 2 ;;
     --skip-dump)      SKIP_DUMP=true; shift ;;
     -h|--help)        usage ;;
     *)                error "Unknown option: $1"; usage ;;
@@ -74,8 +74,8 @@ if [[ "$SKIP_DUMP" == false ]]; then
     error "Missing required argument: --project-id"
     usage
   fi
-  if [[ -z "$ACCESS_TOKEN" ]]; then
-    error "Missing required argument: --access-token"
+  if [[ -z "$PROD_DB_PASSWORD" ]]; then
+    error "Missing required argument: --db-password"
     usage
   fi
 fi
@@ -134,8 +134,10 @@ fi
 # -----------------------------------------------------------------------------
 if [[ "$SKIP_DUMP" == false ]]; then
   info "Dumping production data (read-only)..."
-  SUPABASE_ACCESS_TOKEN="$ACCESS_TOKEN" npx supabase db dump \
-    --project-ref "$PROJECT_ID" \
+  # Build the production DB URL using the connection pooler (works around WSL2 IPv6 issues)
+  PROD_DB_URL="postgresql://postgres.${PROJECT_ID}:${PROD_DB_PASSWORD}@aws-0-eu-west-2.pooler.supabase.com:5432/postgres"
+  npx supabase db dump \
+    --db-url "$PROD_DB_URL" \
     --data-only \
     -f "$DUMP_FILE"
   success "Production dump saved to ${DUMP_FILE}"

--- a/scripts/db-restore-local.sh
+++ b/scripts/db-restore-local.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# db-restore-local.sh
+#
+# Dumps production data (read-only) and restores it into the local Supabase
+# Docker instance. Production is never written to.
+#
+# Usage:
+#   ./scripts/db-restore-local.sh --project-id <PROD_PROJECT_ID> --access-token <SUPABASE_ACCESS_TOKEN>
+#
+# Prerequisites:
+#   - Local Supabase running (supabase start)
+#   - psql installed
+#   - Supabase CLI installed (npx supabase)
+# =============================================================================
+
+DUMP_FILE="supabase/seed.sql"
+LOCAL_DB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+
+# -----------------------------------------------------------------------------
+# Colour helpers
+# -----------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No colour
+
+info()    { echo -e "${BLUE}[INFO]${NC}  $*"; }
+success() { echo -e "${GREEN}[OK]${NC}    $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# -----------------------------------------------------------------------------
+# Usage
+# -----------------------------------------------------------------------------
+usage() {
+  cat <<EOF
+Usage: $0 --project-id <PROD_PROJECT_ID> --access-token <SUPABASE_ACCESS_TOKEN>
+
+Dumps production data (read-only) and restores it into the local Supabase instance.
+
+Options:
+  --project-id     Production Supabase project ID (read-only dump)
+  --access-token   Supabase personal access token
+  --skip-dump      Skip the dump step and use existing supabase/seed.sql
+  -h, --help       Show this help message
+EOF
+  exit 0
+}
+
+# -----------------------------------------------------------------------------
+# Parse arguments
+# -----------------------------------------------------------------------------
+PROJECT_ID=""
+ACCESS_TOKEN=""
+SKIP_DUMP=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-id)     PROJECT_ID="$2"; shift 2 ;;
+    --access-token)   ACCESS_TOKEN="$2"; shift 2 ;;
+    --skip-dump)      SKIP_DUMP=true; shift ;;
+    -h|--help)        usage ;;
+    *)                error "Unknown option: $1"; usage ;;
+  esac
+done
+
+# Validate required arguments (unless skipping dump)
+if [[ "$SKIP_DUMP" == false ]]; then
+  if [[ -z "$PROJECT_ID" ]]; then
+    error "Missing required argument: --project-id"
+    usage
+  fi
+  if [[ -z "$ACCESS_TOKEN" ]]; then
+    error "Missing required argument: --access-token"
+    usage
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# Preflight checks
+# -----------------------------------------------------------------------------
+info "Running preflight checks..."
+
+# Check psql is available
+if ! command -v psql &>/dev/null; then
+  error "psql is not installed. Install PostgreSQL client tools."
+  exit 1
+fi
+success "psql found: $(psql --version)"
+
+# Check Supabase CLI is available
+if ! npx supabase --version &>/dev/null; then
+  error "Supabase CLI not found. Run: pnpm install"
+  exit 1
+fi
+success "Supabase CLI found"
+
+# Check local Supabase is running
+if ! psql "$LOCAL_DB_URL" -c "SELECT 1" &>/dev/null; then
+  error "Local Supabase is not running. Start it with: supabase start"
+  exit 1
+fi
+success "Local Supabase is running"
+
+# -----------------------------------------------------------------------------
+# Confirmation
+# -----------------------------------------------------------------------------
+echo ""
+echo "============================================="
+echo "  LOCAL DATABASE RESTORE"
+echo "============================================="
+echo ""
+if [[ "$SKIP_DUMP" == false ]]; then
+  info "Source:      Production project ${PROJECT_ID} (READ-ONLY dump)"
+fi
+info "Destination: Local Supabase (127.0.0.1:54322)"
+info "Dump file:   ${DUMP_FILE}"
+echo ""
+warn "This will CLEAR all data in your local Supabase database."
+echo ""
+
+read -rp "Continue? (y/N): " confirm
+if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+  info "Aborted."
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Step 1: Dump production data (read-only)
+# -----------------------------------------------------------------------------
+if [[ "$SKIP_DUMP" == false ]]; then
+  info "Dumping production data (read-only)..."
+  SUPABASE_ACCESS_TOKEN="$ACCESS_TOKEN" npx supabase db dump \
+    --project-ref "$PROJECT_ID" \
+    --data-only \
+    -f "$DUMP_FILE"
+  success "Production dump saved to ${DUMP_FILE}"
+else
+  if [[ ! -f "$DUMP_FILE" ]]; then
+    error "Dump file not found at ${DUMP_FILE}. Run without --skip-dump first."
+    exit 1
+  fi
+  info "Using existing dump file: ${DUMP_FILE}"
+fi
+
+# -----------------------------------------------------------------------------
+# Step 2: Clear local database
+# -----------------------------------------------------------------------------
+info "Clearing local database..."
+
+psql "$LOCAL_DB_URL" <<'SQL'
+SET session_replication_role = replica;
+
+-- Clear public tables (reverse dependency order)
+TRUNCATE TABLE public.weekly_statistics CASCADE;
+TRUNCATE TABLE public.player_statistics CASCADE;
+TRUNCATE TABLE public.drafted_transfers CASCADE;
+TRUNCATE TABLE public.drafted_players CASCADE;
+TRUNCATE TABLE public.settings CASCADE;
+TRUNCATE TABLE public.profiles CASCADE;
+TRUNCATE TABLE public.fixtures CASCADE;
+TRUNCATE TABLE public.players CASCADE;
+TRUNCATE TABLE public.teams CASCADE;
+TRUNCATE TABLE public.drafted_teams CASCADE;
+
+-- Clear auth tables
+TRUNCATE TABLE auth.mfa_amr_claims CASCADE;
+TRUNCATE TABLE auth.refresh_tokens CASCADE;
+TRUNCATE TABLE auth.sessions CASCADE;
+TRUNCATE TABLE auth.users CASCADE;
+TRUNCATE TABLE auth.audit_log_entries CASCADE;
+
+-- Reset public sequences
+DO $$
+DECLARE
+  seq RECORD;
+BEGIN
+  FOR seq IN
+    SELECT sequencename FROM pg_sequences WHERE schemaname = 'public'
+  LOOP
+    EXECUTE format('ALTER SEQUENCE public.%I RESTART WITH 1', seq.sequencename);
+  END LOOP;
+END $$;
+
+SET session_replication_role = DEFAULT;
+SQL
+
+success "Local database cleared"
+
+# -----------------------------------------------------------------------------
+# Step 3: Restore dump to local
+# -----------------------------------------------------------------------------
+info "Restoring data to local database..."
+
+# Filter the dump to remove sections that conflict with existing infrastructure:
+#   - storage.buckets (already exist in fresh Supabase instances)
+#   - storage.objects (references buckets, can cause FK issues)
+#   - storage.s3_multipart_uploads (infrastructure table)
+#   - Any ALTER SEQUENCE on auth schema (permission denied — Supabase owns these)
+FILTERED_DUMP=$(mktemp)
+sed \
+  -e '/^-- Data for Name: buckets; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/^-- Data for Name: objects; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/^-- Data for Name: s3_multipart_uploads; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/^-- Data for Name: s3_multipart_uploads_parts; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/INSERT INTO "storage"."buckets"/d' \
+  -e '/INSERT INTO "storage"."objects"/d' \
+  -e '/INSERT INTO "storage"."s3_multipart_uploads/d' \
+  -e '/ALTER SEQUENCE "auth"\./d' \
+  -e '/SELECT pg_catalog.setval.*auth\./d' \
+  "$DUMP_FILE" > "$FILTERED_DUMP"
+
+# Wrap restore in session_replication_role = replica so foreign key constraints
+# don't block INSERTs when rows arrive out of dependency order (which pg_dump
+# data-only dumps frequently produce).
+ERROR_LOG=$(mktemp)
+
+psql "$LOCAL_DB_URL" --quiet \
+  -v ON_ERROR_STOP=0 \
+  -c "SET session_replication_role = replica;" \
+  -f "$FILTERED_DUMP" \
+  -c "SET session_replication_role = DEFAULT;" \
+  2>"$ERROR_LOG" | grep -v "^SET$" || true
+
+# Report any errors (but don't fail — some warnings are expected)
+if [[ -s "$ERROR_LOG" ]]; then
+  # Filter out known harmless warnings
+  REAL_ERRORS=$(grep -v -E "^(SET|COMMENT|$)" "$ERROR_LOG" | grep -i "error" || true)
+  if [[ -n "$REAL_ERRORS" ]]; then
+    warn "Some errors occurred during restore (review below):"
+    echo "$REAL_ERRORS" | head -20
+    echo ""
+    warn "Full error log: ${ERROR_LOG}"
+  else
+    rm -f "$ERROR_LOG"
+  fi
+else
+  rm -f "$ERROR_LOG"
+fi
+
+rm -f "$FILTERED_DUMP"
+success "Data restored to local database"
+
+# -----------------------------------------------------------------------------
+# Step 4: Verify
+# -----------------------------------------------------------------------------
+info "Verifying restore..."
+
+psql "$LOCAL_DB_URL" --tuples-only --no-align -c "
+  SELECT 'auth.users', count(*) FROM auth.users
+  UNION ALL SELECT 'public.teams', count(*) FROM public.teams
+  UNION ALL SELECT 'public.players', count(*) FROM public.players
+  UNION ALL SELECT 'public.drafted_teams', count(*) FROM public.drafted_teams
+  UNION ALL SELECT 'public.fixtures', count(*) FROM public.fixtures
+  UNION ALL SELECT 'public.player_statistics', count(*) FROM public.player_statistics
+  ORDER BY 1;
+" | while IFS='|' read -r table count; do
+  echo -e "  ${GREEN}${table}${NC}: ${count} rows"
+done
+
+echo ""
+success "Local database restore complete!"

--- a/scripts/db-restore-staging.sh
+++ b/scripts/db-restore-staging.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# db-restore-staging.sh
+#
+# Dumps production data (read-only) and restores it into an existing staging
+# Supabase project. Production is never written to. Staging schema must already
+# be in place (migrations applied via CI/CD).
+#
+# Usage:
+#   ./scripts/db-restore-staging.sh \
+#     --prod-project-id <PROD_ID> \
+#     --access-token <TOKEN> \
+#     --staging-project-id <STAGING_ID> \
+#     --staging-db-password <PASSWORD>
+#
+# Prerequisites:
+#   - psql installed
+#   - Supabase CLI installed (npx supabase)
+# =============================================================================
+
+DUMP_FILE="supabase/seed.sql"
+
+# -----------------------------------------------------------------------------
+# Colour helpers
+# -----------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC}  $*"; }
+success() { echo -e "${GREEN}[OK]${NC}    $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# -----------------------------------------------------------------------------
+# Usage
+# -----------------------------------------------------------------------------
+usage() {
+  cat <<EOF
+Usage: $0 --prod-project-id <ID> --access-token <TOKEN> --staging-project-id <ID> --staging-db-password <PASSWORD>
+
+Dumps production data (read-only) and restores it into an existing staging Supabase project.
+Staging must already have migrations applied (via CI/CD).
+
+Options:
+  --prod-project-id       Production Supabase project ID (read-only dump)
+  --access-token          Supabase personal access token
+  --staging-project-id    Staging Supabase project ID (write target)
+  --staging-db-password   Staging database password
+  --skip-dump             Skip the dump step and use existing supabase/seed.sql
+  -h, --help              Show this help message
+EOF
+  exit 0
+}
+
+# -----------------------------------------------------------------------------
+# Parse arguments
+# -----------------------------------------------------------------------------
+PROD_PROJECT_ID=""
+ACCESS_TOKEN=""
+STAGING_PROJECT_ID=""
+STAGING_DB_PASSWORD=""
+SKIP_DUMP=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prod-project-id)      PROD_PROJECT_ID="$2"; shift 2 ;;
+    --access-token)         ACCESS_TOKEN="$2"; shift 2 ;;
+    --staging-project-id)   STAGING_PROJECT_ID="$2"; shift 2 ;;
+    --staging-db-password)  STAGING_DB_PASSWORD="$2"; shift 2 ;;
+    --skip-dump)            SKIP_DUMP=true; shift ;;
+    -h|--help)              usage ;;
+    *)                      error "Unknown option: $1"; usage ;;
+  esac
+done
+
+# Validate required arguments
+if [[ "$SKIP_DUMP" == false ]]; then
+  [[ -z "$PROD_PROJECT_ID" ]]   && { error "Missing: --prod-project-id"; usage; }
+  [[ -z "$ACCESS_TOKEN" ]]       && { error "Missing: --access-token"; usage; }
+fi
+[[ -z "$STAGING_PROJECT_ID" ]]    && { error "Missing: --staging-project-id"; usage; }
+[[ -z "$STAGING_DB_PASSWORD" ]]   && { error "Missing: --staging-db-password"; usage; }
+
+# Safety: ensure staging and production are different projects
+if [[ "$SKIP_DUMP" == false && "$STAGING_PROJECT_ID" == "$PROD_PROJECT_ID" ]]; then
+  error "SAFETY CHECK FAILED: Staging project ID matches production project ID!"
+  error "This script will NEVER write to production. Aborting."
+  exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Build staging connection URL
+# -----------------------------------------------------------------------------
+# Use the direct connection (port 5432) with IPv4 forced via --host flag
+STAGING_HOST="db.${STAGING_PROJECT_ID}.supabase.co"
+STAGING_DB_URL="postgresql://postgres.${STAGING_PROJECT_ID}:${STAGING_DB_PASSWORD}@aws-0-eu-west-2.pooler.supabase.com:6543/postgres"
+
+# -----------------------------------------------------------------------------
+# Preflight checks
+# -----------------------------------------------------------------------------
+info "Running preflight checks..."
+
+if ! command -v psql &>/dev/null; then
+  error "psql is not installed. Install PostgreSQL client tools."
+  exit 1
+fi
+success "psql found: $(psql --version)"
+
+if ! npx supabase --version &>/dev/null; then
+  error "Supabase CLI not found. Run: pnpm install"
+  exit 1
+fi
+success "Supabase CLI found"
+
+# Test staging connectivity
+info "Testing staging database connectivity..."
+if ! psql "$STAGING_DB_URL" -c "SELECT 1" &>/dev/null 2>&1; then
+  warn "Could not connect to staging via pooler. Trying direct connection..."
+  # Try resolving to IPv4 explicitly
+  STAGING_IPV4=$(getent ahostsv4 "$STAGING_HOST" 2>/dev/null | head -1 | awk '{print $1}' || true)
+  if [[ -n "$STAGING_IPV4" ]]; then
+    STAGING_DB_URL="postgresql://postgres:${STAGING_DB_PASSWORD}@${STAGING_IPV4}:5432/postgres?sslmode=require"
+    if ! psql "$STAGING_DB_URL" -c "SELECT 1" &>/dev/null 2>&1; then
+      error "Cannot connect to staging database. Check credentials and network."
+      error "If in WSL2, you may need to use the Supabase SQL Editor as a fallback."
+      error "See docs/guides/database-restore.md for the manual method."
+      exit 1
+    fi
+    success "Connected to staging via direct IPv4 (${STAGING_IPV4})"
+  else
+    error "Cannot resolve staging host to IPv4. Check network connectivity."
+    exit 1
+  fi
+else
+  success "Connected to staging via connection pooler"
+fi
+
+# -----------------------------------------------------------------------------
+# Confirmation
+# -----------------------------------------------------------------------------
+echo ""
+echo "============================================="
+echo "  STAGING DATABASE RESTORE"
+echo "============================================="
+echo ""
+if [[ "$SKIP_DUMP" == false ]]; then
+  info "Source:      Production project ${PROD_PROJECT_ID} (READ-ONLY dump)"
+fi
+info "Destination: Staging project ${STAGING_PROJECT_ID}"
+info "Dump file:   ${DUMP_FILE}"
+echo ""
+warn "This will CLEAR all data in the staging database and replace it with production data."
+warn "Production will NOT be modified (read-only dump only)."
+echo ""
+
+read -rp "Type 'restore-staging' to confirm: " confirm
+if [[ "$confirm" != "restore-staging" ]]; then
+  info "Aborted."
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Step 1: Dump production data (read-only)
+# -----------------------------------------------------------------------------
+if [[ "$SKIP_DUMP" == false ]]; then
+  info "Dumping production data (read-only)..."
+  SUPABASE_ACCESS_TOKEN="$ACCESS_TOKEN" npx supabase db dump \
+    --project-ref "$PROD_PROJECT_ID" \
+    --data-only \
+    -f "$DUMP_FILE"
+  success "Production dump saved to ${DUMP_FILE}"
+else
+  if [[ ! -f "$DUMP_FILE" ]]; then
+    error "Dump file not found at ${DUMP_FILE}. Run without --skip-dump first."
+    exit 1
+  fi
+  info "Using existing dump file: ${DUMP_FILE}"
+fi
+
+# -----------------------------------------------------------------------------
+# Step 2: Clear staging database
+# -----------------------------------------------------------------------------
+info "Clearing staging database..."
+
+psql "$STAGING_DB_URL" <<'SQL'
+SET session_replication_role = replica;
+
+-- Clear public tables (reverse dependency order)
+TRUNCATE TABLE public.weekly_statistics CASCADE;
+TRUNCATE TABLE public.player_statistics CASCADE;
+TRUNCATE TABLE public.drafted_transfers CASCADE;
+TRUNCATE TABLE public.drafted_players CASCADE;
+TRUNCATE TABLE public.settings CASCADE;
+TRUNCATE TABLE public.profiles CASCADE;
+TRUNCATE TABLE public.fixtures CASCADE;
+TRUNCATE TABLE public.players CASCADE;
+TRUNCATE TABLE public.teams CASCADE;
+TRUNCATE TABLE public.drafted_teams CASCADE;
+
+-- Clear auth tables
+TRUNCATE TABLE auth.mfa_amr_claims CASCADE;
+TRUNCATE TABLE auth.refresh_tokens CASCADE;
+TRUNCATE TABLE auth.sessions CASCADE;
+TRUNCATE TABLE auth.users CASCADE;
+TRUNCATE TABLE auth.audit_log_entries CASCADE;
+
+-- Reset public sequences
+DO $$
+DECLARE
+  seq RECORD;
+BEGIN
+  FOR seq IN
+    SELECT sequencename FROM pg_sequences WHERE schemaname = 'public'
+  LOOP
+    EXECUTE format('ALTER SEQUENCE public.%I RESTART WITH 1', seq.sequencename);
+  END LOOP;
+END $$;
+
+SET session_replication_role = DEFAULT;
+SQL
+
+success "Staging database cleared"
+
+# -----------------------------------------------------------------------------
+# Step 3: Restore dump to staging
+# -----------------------------------------------------------------------------
+info "Restoring data to staging database..."
+
+# Filter the dump to remove sections that conflict with existing infrastructure:
+#   - storage.buckets (already exist in fresh Supabase instances)
+#   - storage.objects (references buckets, can cause FK issues)
+#   - storage.s3_multipart_uploads (infrastructure table)
+#   - Any ALTER SEQUENCE on auth schema (permission denied — Supabase owns these)
+FILTERED_DUMP=$(mktemp)
+sed \
+  -e '/^-- Data for Name: buckets; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/^-- Data for Name: objects; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/^-- Data for Name: s3_multipart_uploads; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/^-- Data for Name: s3_multipart_uploads_parts; Type: TABLE DATA; Schema: storage/,/^$/d' \
+  -e '/INSERT INTO "storage"."buckets"/d' \
+  -e '/INSERT INTO "storage"."objects"/d' \
+  -e '/INSERT INTO "storage"."s3_multipart_uploads/d' \
+  -e '/ALTER SEQUENCE "auth"\./d' \
+  -e '/SELECT pg_catalog.setval.*auth\./d' \
+  "$DUMP_FILE" > "$FILTERED_DUMP"
+
+# Wrap restore in session_replication_role = replica so foreign key constraints
+# don't block INSERTs when rows arrive out of dependency order (which pg_dump
+# data-only dumps frequently produce).
+ERROR_LOG=$(mktemp)
+
+psql "$STAGING_DB_URL" --quiet \
+  -v ON_ERROR_STOP=0 \
+  -c "SET session_replication_role = replica;" \
+  -f "$FILTERED_DUMP" \
+  -c "SET session_replication_role = DEFAULT;" \
+  2>"$ERROR_LOG" | grep -v "^SET$" || true
+
+# Report any errors (but don't fail — some warnings are expected)
+if [[ -s "$ERROR_LOG" ]]; then
+  # Filter out known harmless warnings
+  REAL_ERRORS=$(grep -v -E "^(SET|COMMENT|$)" "$ERROR_LOG" | grep -i "error" || true)
+  if [[ -n "$REAL_ERRORS" ]]; then
+    warn "Some errors occurred during restore (review below):"
+    echo "$REAL_ERRORS" | head -20
+    echo ""
+    warn "Full error log: ${ERROR_LOG}"
+  else
+    rm -f "$ERROR_LOG"
+  fi
+else
+  rm -f "$ERROR_LOG"
+fi
+
+rm -f "$FILTERED_DUMP"
+success "Data restored to staging database"
+
+# -----------------------------------------------------------------------------
+# Step 4: Verify
+# -----------------------------------------------------------------------------
+info "Verifying restore..."
+
+psql "$STAGING_DB_URL" --tuples-only --no-align -c "
+  SELECT 'auth.users', count(*) FROM auth.users
+  UNION ALL SELECT 'public.teams', count(*) FROM public.teams
+  UNION ALL SELECT 'public.players', count(*) FROM public.players
+  UNION ALL SELECT 'public.drafted_teams', count(*) FROM public.drafted_teams
+  UNION ALL SELECT 'public.fixtures', count(*) FROM public.fixtures
+  UNION ALL SELECT 'public.player_statistics', count(*) FROM public.player_statistics
+  ORDER BY 1;
+" | while IFS='|' read -r table count; do
+  echo -e "  ${GREEN}${table}${NC}: ${count} rows"
+done
+
+echo ""
+success "Staging database restore complete!"

--- a/scripts/db-restore-staging.sh
+++ b/scripts/db-restore-staging.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # Usage:
 #   ./scripts/db-restore-staging.sh \
 #     --prod-project-id <PROD_ID> \
-#     --access-token <TOKEN> \
+#     --prod-db-password <PROD_DB_PASSWORD> \
 #     --staging-project-id <STAGING_ID> \
 #     --staging-db-password <PASSWORD>
 #
@@ -41,14 +41,14 @@ error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 # -----------------------------------------------------------------------------
 usage() {
   cat <<EOF
-Usage: $0 --prod-project-id <ID> --access-token <TOKEN> --staging-project-id <ID> --staging-db-password <PASSWORD>
+Usage: $0 --prod-project-id <ID> --prod-db-password <PASSWORD> --staging-project-id <ID> --staging-db-password <PASSWORD>
 
 Dumps production data (read-only) and restores it into an existing staging Supabase project.
 Staging must already have migrations applied (via CI/CD).
 
 Options:
   --prod-project-id       Production Supabase project ID (read-only dump)
-  --access-token          Supabase personal access token
+  --prod-db-password      Production database password
   --staging-project-id    Staging Supabase project ID (write target)
   --staging-db-password   Staging database password
   --skip-dump             Skip the dump step and use existing supabase/seed.sql
@@ -61,7 +61,7 @@ EOF
 # Parse arguments
 # -----------------------------------------------------------------------------
 PROD_PROJECT_ID=""
-ACCESS_TOKEN=""
+PROD_DB_PASSWORD=""
 STAGING_PROJECT_ID=""
 STAGING_DB_PASSWORD=""
 SKIP_DUMP=false
@@ -69,7 +69,7 @@ SKIP_DUMP=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --prod-project-id)      PROD_PROJECT_ID="$2"; shift 2 ;;
-    --access-token)         ACCESS_TOKEN="$2"; shift 2 ;;
+    --prod-db-password)     PROD_DB_PASSWORD="$2"; shift 2 ;;
     --staging-project-id)   STAGING_PROJECT_ID="$2"; shift 2 ;;
     --staging-db-password)  STAGING_DB_PASSWORD="$2"; shift 2 ;;
     --skip-dump)            SKIP_DUMP=true; shift ;;
@@ -81,7 +81,7 @@ done
 # Validate required arguments
 if [[ "$SKIP_DUMP" == false ]]; then
   [[ -z "$PROD_PROJECT_ID" ]]   && { error "Missing: --prod-project-id"; usage; }
-  [[ -z "$ACCESS_TOKEN" ]]       && { error "Missing: --access-token"; usage; }
+  [[ -z "$PROD_DB_PASSWORD" ]]  && { error "Missing: --prod-db-password"; usage; }
 fi
 [[ -z "$STAGING_PROJECT_ID" ]]    && { error "Missing: --staging-project-id"; usage; }
 [[ -z "$STAGING_DB_PASSWORD" ]]   && { error "Missing: --staging-db-password"; usage; }
@@ -169,8 +169,9 @@ fi
 # -----------------------------------------------------------------------------
 if [[ "$SKIP_DUMP" == false ]]; then
   info "Dumping production data (read-only)..."
-  SUPABASE_ACCESS_TOKEN="$ACCESS_TOKEN" npx supabase db dump \
-    --project-ref "$PROD_PROJECT_ID" \
+  PROD_DB_URL="postgresql://postgres.${PROD_PROJECT_ID}:${PROD_DB_PASSWORD}@aws-0-eu-west-2.pooler.supabase.com:5432/postgres"
+  npx supabase db dump \
+    --db-url "$PROD_DB_URL" \
     --data-only \
     -f "$DUMP_FILE"
   success "Production dump saved to ${DUMP_FILE}"


### PR DESCRIPTION
## Summary

- Removes all production credentials from the local dev environment (project ID from `package.json`, DB URLs from `.env`)
- Adds three bash scripts in `scripts/` for data restoration — all read-only against production
- Hardens `.gitignore` to block all `.env.*` variants and unlinks the Supabase CLI from production
- Documents strict database safety rules in `CLAUDE.md` to prevent AI assistants from accidentally targeting remote databases

## Scripts added

| Script | Purpose | Writes to |
|--------|---------|-----------|
| `db-restore-local.sh` | Pull live data into local Supabase Docker instance | Local only (127.0.0.1) |
| `db-restore-staging.sh` | Refresh an existing staging environment from live | Staging only |
| `db-rebuild-staging.sh` | Full rebuild of a new staging project from live | Staging only |

Run with:
```bash
./scripts/db-restore-local.sh --project-id <ID> --db-password <PASSWORD>
```

Credentials are passed as CLI arguments only — never stored in any file.

## Safety guarantees

- Production is read-only (dump via `pg_dump` — structurally cannot write back)
- Local restore target is hardcoded to `127.0.0.1:54322`
- Staging scripts verify the staging project ID does not match production before proceeding
- Scripts are intentionally not listed in `package.json` — they must be run manually at the terminal