### PR TITLE
Show team submission history to admins

### DIFF
--- a/app/components/Drafted/DraftedTeam.vue
+++ b/app/components/Drafted/DraftedTeam.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import DraftedPlayer from './DraftedPlayer.vue';
-import TeamAdminMetadataPopover from './TeamAdminMetadataPopover.vue';
+import TeamAdminMetadataPopover from '~/components/Drafted/TeamAdminMetadataPopover.vue';
 import type { DraftedTeamWithPlayers, TeamAdminMetadata } from '~/types/DraftedTeam';
 
 const props = defineProps({

--- a/app/components/Drafted/DraftedTeam.vue
+++ b/app/components/Drafted/DraftedTeam.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import DraftedPlayer from './DraftedPlayer.vue';
+import TeamAdminMetadataPopover from './TeamAdminMetadataPopover.vue';
 import type { DraftedTeamWithPlayers, TeamAdminMetadata } from '~/types/DraftedTeam';
 
 const props = defineProps({

--- a/app/components/Drafted/DraftedTeam.vue
+++ b/app/components/Drafted/DraftedTeam.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import DraftedPlayer from './DraftedPlayer.vue';
-import type { DraftedTeamWithPlayers } from '~/types/DraftedTeam';
+import type { DraftedTeamWithPlayers, TeamAdminMetadata } from '~/types/DraftedTeam';
 
 const props = defineProps({
   draftedTeam: {
@@ -10,6 +10,10 @@ const props = defineProps({
   editable: {
     type: Boolean,
     default: false,
+  },
+  adminMetadata: {
+    type: Object as PropType<TeamAdminMetadata>,
+    default: undefined,
   },
 });
 
@@ -56,15 +60,24 @@ const handleEditPlayer = (playerID: number) => {
           props.draftedTeam?.team_owner
         }}</span>
       </div>
-      <UTooltip
-        v-if="props.draftedTeam?.allowed_transfers"
-        text="Transfers allowed"
+      <div
+        v-if="props.draftedTeam?.allowed_transfers || props.adminMetadata"
+        class="flex items-center gap-1"
       >
-        <Icon
-          size="24"
-          name="ic:round-swap-horiz"
+        <UTooltip
+          v-if="props.draftedTeam?.allowed_transfers"
+          text="Transfers allowed"
+        >
+          <Icon
+            size="24"
+            name="ic:round-swap-horiz"
+          />
+        </UTooltip>
+        <TeamAdminMetadataPopover
+          v-if="props.adminMetadata"
+          :metadata="props.adminMetadata"
         />
-      </UTooltip>
+      </div>
     </div>
     <div
       v-for="player in props.draftedTeam.players"

--- a/app/components/Drafted/TeamAdminMetadataPopover.vue
+++ b/app/components/Drafted/TeamAdminMetadataPopover.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import type { TeamAdminMetadata } from '~/types/DraftedTeam';
+
+const props = defineProps<{
+  metadata: TeamAdminMetadata;
+}>();
+
+const dateFormatter = new Intl.DateTimeFormat('en-GB', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+const formatDate = (value: string) => dateFormatter.format(new Date(value));
+</script>
+
+<template>
+  <UPopover
+    :content="{
+      align: 'end',
+      side: 'bottom',
+    }"
+  >
+    <UButton
+      icon="lucide:history"
+      color="neutral"
+      variant="ghost"
+      size="xs"
+      square
+      aria-label="View submission history"
+      title="View submission history"
+    />
+
+    <template #content>
+      <div class="w-64 p-4 text-slate-900 dark:text-slate-100">
+        <p class="mb-3 text-sm font-bold uppercase tracking-wide">
+          Submission history
+        </p>
+        <dl class="space-y-2 text-sm">
+          <div class="flex items-start justify-between gap-4">
+            <dt class="text-slate-500 dark:text-slate-400">
+              Created
+            </dt>
+            <dd class="text-right font-medium">
+              {{ formatDate(props.metadata.created_at) }}
+            </dd>
+          </div>
+          <div class="flex items-start justify-between gap-4">
+            <dt class="text-slate-500 dark:text-slate-400">
+              Last edited
+            </dt>
+            <dd class="text-right font-medium">
+              {{ props.metadata.updated_at ? formatDate(props.metadata.updated_at) : 'Never edited' }}
+            </dd>
+          </div>
+          <div class="flex items-start justify-between gap-4">
+            <dt class="text-slate-500 dark:text-slate-400">
+              Edit count
+            </dt>
+            <dd class="text-right font-medium">
+              {{ props.metadata.edited_count ?? 0 }}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </template>
+  </UPopover>
+</template>

--- a/app/pages/teams/index.vue
+++ b/app/pages/teams/index.vue
@@ -4,13 +4,20 @@ import { useDraftedTeamsStore } from '@/stores/draftedTeams';
 const draftedTeamsStore = useDraftedTeamsStore();
 const user = useSupabaseUser();
 
-draftedTeamsStore.clearDraftedTeamAdminMetadata();
+const loadAdminMetadata = async (isAuthenticated: boolean) => {
+  if (!isAuthenticated) {
+    draftedTeamsStore.clearDraftedTeamAdminMetadata();
+    return;
+  }
+
+  await draftedTeamsStore.fetchDraftedTeamAdminMetadata();
+};
+
+watch(user, currentUser => loadAdminMetadata(Boolean(currentUser)));
 
 await Promise.all([
   draftedTeamsStore.fetchDraftedTeams(),
-  user.value
-    ? draftedTeamsStore.fetchDraftedTeamAdminMetadata()
-    : Promise.resolve(),
+  loadAdminMetadata(Boolean(user.value)),
 ]);
 </script>
 

--- a/app/pages/teams/index.vue
+++ b/app/pages/teams/index.vue
@@ -2,7 +2,16 @@
 import { useDraftedTeamsStore } from '@/stores/draftedTeams';
 
 const draftedTeamsStore = useDraftedTeamsStore();
-await draftedTeamsStore.fetchDraftedTeams();
+const user = useSupabaseUser();
+
+draftedTeamsStore.clearDraftedTeamAdminMetadata();
+
+await Promise.all([
+  draftedTeamsStore.fetchDraftedTeams(),
+  user.value
+    ? draftedTeamsStore.fetchDraftedTeamAdminMetadata()
+    : Promise.resolve(),
+]);
 </script>
 
 <template>
@@ -16,6 +25,9 @@ await draftedTeamsStore.fetchDraftedTeams();
         <DraftedTeam
           v-if="draftedTeam"
           :drafted-team="draftedTeam"
+          :admin-metadata="user
+            ? draftedTeamsStore.getDraftedTeamAdminMetadataByID(draftedTeam.drafted_team_id)
+            : undefined"
         />
       </div>
     </div>

--- a/app/stores/draftedTeams.ts
+++ b/app/stores/draftedTeams.ts
@@ -3,6 +3,7 @@ import { initDraftedTeamData } from '~/logic/drafted-teams';
 import type { DraftedPlayer } from '~/types/DraftedPlayer';
 import type {
   DraftedTeamWithPlayers,
+  TeamAdminMetadata,
 } from '~/types/DraftedTeam';
 import type { Database, TablesInsert } from '~/types/database.types';
 
@@ -11,6 +12,7 @@ export const useDraftedTeamsStore = defineStore('drafted-teams-store', () => {
   const { getActiveSeason } = useAppSettings();
 
   const draftedTeams: Ref<DraftedTeamWithPlayers[] | null> = ref(null);
+  const draftedTeamAdminMetadata: Ref<Record<number, TeamAdminMetadata>> = ref({});
 
   const getDraftedTeams = computed(() =>
     initDraftedTeamData(draftedTeams.value),
@@ -23,12 +25,34 @@ export const useDraftedTeamsStore = defineStore('drafted-teams-store', () => {
       draftedTeamsValue?.find(x => x.drafted_team_id === id);
   });
 
+  const getDraftedTeamAdminMetadataByID = computed(() => {
+    return (id: number) => draftedTeamAdminMetadata.value[id];
+  });
+
   const fetchDraftedTeams = async () => {
     const activeSeason = await getActiveSeason();
     const { data, error } = await supabase
       .rpc('get_drafted_teams_by_season', { active_season_param: activeSeason });
     if (error) throw error;
     draftedTeams.value = data;
+  };
+
+  const fetchDraftedTeamAdminMetadata = async () => {
+    const activeSeason = await getActiveSeason();
+    const { data, error } = await supabase
+      .from('drafted_teams')
+      .select('drafted_team_id, created_at, updated_at, edited_count')
+      .eq('active_season', activeSeason);
+
+    if (error) throw error;
+
+    draftedTeamAdminMetadata.value = Object.fromEntries(
+      (data ?? []).map(metadata => [metadata.drafted_team_id, metadata]),
+    );
+  };
+
+  const clearDraftedTeamAdminMetadata = () => {
+    draftedTeamAdminMetadata.value = {};
   };
 
   const fetchDraftedTeamsWithPlayerPointsByGameweek = async (
@@ -137,9 +161,13 @@ export const useDraftedTeamsStore = defineStore('drafted-teams-store', () => {
 
   return {
     draftedTeams,
+    draftedTeamAdminMetadata,
     getDraftedTeams,
     getDraftedTeamByID,
+    getDraftedTeamAdminMetadataByID,
     fetchDraftedTeams,
+    fetchDraftedTeamAdminMetadata,
+    clearDraftedTeamAdminMetadata,
     fetchDraftedPlayerByID,
     fetchDraftedTeamsWithPlayerPointsByGameweek,
     upsertDraftedTeam,

--- a/app/tests/drafted/components/DraftedTeam.test.ts
+++ b/app/tests/drafted/components/DraftedTeam.test.ts
@@ -1,0 +1,35 @@
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { describe, expect, it } from 'vitest';
+import DraftedTeam from '~/components/Drafted/DraftedTeam.vue';
+import { createMockDraftedTeam, createMockTeamAdminMetadata } from '~/tests/factories';
+
+const SlotStub = defineComponent({
+  template: '<div><slot /><slot name="content" /></div>',
+});
+
+describe('DraftedTeam', () => {
+  it('renders the submission history control when admin metadata is provided', () => {
+    const wrapper = mount(DraftedTeam, {
+      props: {
+        draftedTeam: createMockDraftedTeam(),
+        adminMetadata: createMockTeamAdminMetadata(),
+      },
+      global: {
+        stubs: {
+          DraftedPlayerEditDialog: true,
+          Icon: true,
+          UButton: defineComponent({
+            inheritAttrs: false,
+            template: '<button v-bind="$attrs" />',
+          }),
+          UCard: SlotStub,
+          UPopover: SlotStub,
+          UTooltip: SlotStub,
+        },
+      },
+    });
+
+    expect(wrapper.find('[aria-label="View submission history"]').exists()).toBe(true);
+  });
+});

--- a/app/tests/drafted/components/TeamAdminMetadataPopover.test.ts
+++ b/app/tests/drafted/components/TeamAdminMetadataPopover.test.ts
@@ -1,0 +1,51 @@
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { describe, expect, it } from 'vitest';
+import TeamAdminMetadataPopover from '~/components/Drafted/TeamAdminMetadataPopover.vue';
+import { createMockTeamAdminMetadata } from '~/tests/factories';
+
+const UPopoverStub = defineComponent({
+  template: '<div><slot /><div data-testid="popover-content"><slot name="content" /></div></div>',
+});
+
+const UButtonStub = defineComponent({
+  inheritAttrs: false,
+  template: '<button v-bind="$attrs" />',
+});
+
+const mountPopover = (updatedAt: string | null, editedCount: number | null) =>
+  mount(TeamAdminMetadataPopover, {
+    props: {
+      metadata: createMockTeamAdminMetadata({
+        updated_at: updatedAt,
+        edited_count: editedCount,
+      }),
+    },
+    global: {
+      stubs: {
+        UButton: UButtonStub,
+        UPopover: UPopoverStub,
+      },
+    },
+  });
+
+describe('TeamAdminMetadataPopover', () => {
+  it('shows the created date, last-edited date, and edit count', () => {
+    const wrapper = mountPopover('2025-01-14T18:30:00Z', 2);
+
+    expect(wrapper.get('button').attributes('aria-label')).toBe('View submission history');
+    expect(wrapper.get('[data-testid="popover-content"]').text()).toContain('Created');
+    expect(wrapper.get('[data-testid="popover-content"]').text()).toContain('12 Jan 2025');
+    expect(wrapper.get('[data-testid="popover-content"]').text()).toContain('Last edited');
+    expect(wrapper.get('[data-testid="popover-content"]').text()).toContain('14 Jan 2025');
+    expect(wrapper.get('[data-testid="popover-content"]').text()).toContain('Edit count');
+    expect(wrapper.get('[data-testid="popover-content"]').text()).toContain('2');
+  });
+
+  it('handles a team that has never been edited', () => {
+    const wrapper = mountPopover(null, null);
+
+    expect(wrapper.get('[data-testid="popover-content"]').text()).toContain('Never edited');
+    expect(wrapper.get('[data-testid="popover-content"]').text()).toContain('0');
+  });
+});

--- a/app/tests/factories/index.ts
+++ b/app/tests/factories/index.ts
@@ -1,6 +1,7 @@
 // Central exports for all test fixtures
 export {
   createMockDraftedTeam,
+  createMockTeamAdminMetadata,
   createMockTeamInsertData,
   createMockTeamTableData,
 } from './teams';

--- a/app/tests/factories/teams.ts
+++ b/app/tests/factories/teams.ts
@@ -1,5 +1,15 @@
-import type { DraftedTeamWithPlayers } from '@/types/DraftedTeam';
-import type { TablesInsert, Tables } from '@/types/database.types';
+import type { DraftedTeamWithPlayers, TeamAdminMetadata } from '~/types/DraftedTeam';
+import type { TablesInsert, Tables } from '~/types/database.types';
+
+export const createMockTeamAdminMetadata = (
+  overrides?: Partial<TeamAdminMetadata>,
+): TeamAdminMetadata => ({
+  drafted_team_id: 1,
+  created_at: '2025-01-12T10:00:00Z',
+  updated_at: null,
+  edited_count: 0,
+  ...overrides,
+});
 
 /**
  * Factory function for creating mock DraftedTeam data for testing.

--- a/app/tests/teams/pages/TeamsPage.test.ts
+++ b/app/tests/teams/pages/TeamsPage.test.ts
@@ -1,0 +1,71 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { flushPromises, mount } from '@vue/test-utils';
+import { defineComponent, nextTick, ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import TeamsPage from '~/pages/teams/index.vue';
+
+const user = ref<{ id: string } | null>(null);
+
+const state = vi.hoisted(() => ({
+  metadataLoaded: false,
+}));
+
+const store = vi.hoisted(() => ({
+  clearDraftedTeamAdminMetadata: vi.fn(),
+  fetchDraftedTeamAdminMetadata: vi.fn().mockImplementation(async () => {
+    state.metadataLoaded = true;
+  }),
+  fetchDraftedTeams: vi.fn().mockResolvedValue(undefined),
+  getDraftedTeamAdminMetadataByID: vi.fn(() => state.metadataLoaded
+    ? {
+        drafted_team_id: 1,
+        created_at: '2025-01-12T10:00:00Z',
+        updated_at: null,
+        edited_count: 0,
+      }
+    : undefined),
+  getDraftedTeams: [{ drafted_team_id: 1 }],
+}));
+
+mockNuxtImport('useSupabaseUser', () => {
+  return () => user;
+});
+
+vi.mock('~/stores/draftedTeams', () => ({
+  useDraftedTeamsStore: () => store,
+}));
+
+describe('teams page admin metadata', () => {
+  beforeEach(() => {
+    user.value = null;
+    state.metadataLoaded = false;
+    vi.clearAllMocks();
+  });
+
+  it('loads admin metadata when an authenticated session is restored after mount', async () => {
+    const wrapper = mount(defineComponent({
+      components: { TeamsPage },
+      template: '<Suspense><TeamsPage /></Suspense>',
+    }), {
+      global: {
+        stubs: {
+          DraftedTeam: defineComponent({
+            props: ['adminMetadata'],
+            template: '<button v-if="adminMetadata" aria-label="View submission history" />',
+          }),
+          SkeletonDraftedTeam: true,
+        },
+      },
+    });
+    await flushPromises();
+
+    expect(store.fetchDraftedTeamAdminMetadata).not.toHaveBeenCalled();
+
+    user.value = { id: 'admin-user' };
+    await flushPromises();
+    await nextTick();
+
+    expect(store.fetchDraftedTeamAdminMetadata).toHaveBeenCalledOnce();
+    expect(wrapper.find('[aria-label="View submission history"]').exists()).toBe(true);
+  });
+});

--- a/app/tests/teams/pages/TeamsPage.test.ts
+++ b/app/tests/teams/pages/TeamsPage.test.ts
@@ -3,11 +3,14 @@ import { flushPromises, mount } from '@vue/test-utils';
 import { defineComponent, nextTick, ref } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import TeamsPage from '~/pages/teams/index.vue';
+import { createMockDraftedTeam, createMockTeamAdminMetadata } from '~/tests/factories';
+import type { DraftedTeamWithPlayers, TeamAdminMetadata } from '~/types/DraftedTeam';
 
 const user = ref<{ id: string } | null>(null);
 
 const state = vi.hoisted(() => ({
   metadataLoaded: false,
+  metadata: undefined as TeamAdminMetadata | undefined,
 }));
 
 const store = vi.hoisted(() => ({
@@ -17,14 +20,9 @@ const store = vi.hoisted(() => ({
   }),
   fetchDraftedTeams: vi.fn().mockResolvedValue(undefined),
   getDraftedTeamAdminMetadataByID: vi.fn(() => state.metadataLoaded
-    ? {
-        drafted_team_id: 1,
-        created_at: '2025-01-12T10:00:00Z',
-        updated_at: null,
-        edited_count: 0,
-      }
+    ? state.metadata
     : undefined),
-  getDraftedTeams: [{ drafted_team_id: 1 }],
+  getDraftedTeams: [] as DraftedTeamWithPlayers[],
 }));
 
 mockNuxtImport('useSupabaseUser', () => {
@@ -39,6 +37,8 @@ describe('teams page admin metadata', () => {
   beforeEach(() => {
     user.value = null;
     state.metadataLoaded = false;
+    state.metadata = createMockTeamAdminMetadata();
+    store.getDraftedTeams = [createMockDraftedTeam()];
     vi.clearAllMocks();
   });
 

--- a/app/types/DraftedTeam.ts
+++ b/app/types/DraftedTeam.ts
@@ -2,6 +2,10 @@ import type { Tables } from './database.types';
 import type { DraftedPlayerWithWeeklyStats } from './DraftedPlayer';
 
 type DraftedTeam = Tables<'drafted_teams'> & { is_invalid_team: boolean };
+type TeamAdminMetadata = Pick<
+  Tables<'drafted_teams'>,
+  'drafted_team_id' | 'created_at' | 'updated_at' | 'edited_count'
+>;
 type DraftedTeamWithPlayers = DraftedTeam & {
   players: DraftedPlayerWithWeeklyStats[];
 };
@@ -13,4 +17,10 @@ type DraftedTeamWithWeeklyStats = DraftedTeam & {
 
 type WeeklyStats = Tables<'weekly_statistics'>;
 
-export type { DraftedTeam, DraftedTeamWithPlayers, DraftedTeamWithWeeklyStats, WeeklyStats };
+export type {
+  DraftedTeam,
+  DraftedTeamWithPlayers,
+  DraftedTeamWithWeeklyStats,
+  TeamAdminMetadata,
+  WeeklyStats,
+};

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -95,6 +95,16 @@ For staging and production:
 6. Exercise any forms, server API routes, or migrations changed by the release.
 7. Check desktop and mobile layouts in light and dark mode for UI changes.
 
+For admin team submission metadata changes:
+
+1. Confirm the metadata permission migration was applied successfully.
+2. While signed out, confirm team cards have no submission-history control.
+3. While signed in as an administrator, confirm the control shows created,
+   last-edited, and edit-count values on `/teams`.
+4. Confirm the anonymous Supabase role cannot select `created_at`, `updated_at`,
+   or `edited_count` from `drafted_teams`.
+5. Confirm the authenticated role can still select those fields.
+
 ## Rollback
 
 Frontend rollback depends on the hosting platform. Prefer redeploying the last known-good application artifact or commit.
@@ -121,4 +131,4 @@ The repository has no frontend deployment job. To close that gap:
 
 ---
 
-**Last updated:** 2026-07-28
+**Last updated:** 2026-08-02

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -2,7 +2,7 @@
 
 **League of our own** - Fantasy Football Web Application
 
-*Last updated: 2026-07-20*
+*Last updated: 2026-08-02*
 
 ## Overview
 
@@ -246,6 +246,24 @@ app/types/
 - **Authentication**: Custom user profiles with role-based access
 - **Real-time Updates**: Live data synchronisation
 - **Row Level Security**: Data access control
+
+#### Team Submission Metadata Privacy
+
+The `drafted_teams.created_at`, `updated_at`, and `edited_count` fields expose
+operational submission history. Public league views do not need this history,
+so public team functions omit the fields and anonymous users have no direct
+column privileges for them. The Teams page fetches them separately only after
+Supabase provides an authenticated user, then displays them in an admin-only
+popover.
+
+The client-side visibility check is a user-interface convenience, not the
+security control. PostgreSQL grants are responsible for preventing anonymous
+reads even if someone calls Supabase directly.
+
+This design assumes every authenticated account is an administrator, matching
+the application's current account model. If member accounts are introduced,
+replace that assumption with an explicit administrator role in both database
+policies and the UI authorization check.
 
 #### Email Service Integration
 - **Resend Service**: HTML email delivery

--- a/docs/reference/database.md
+++ b/docs/reference/database.md
@@ -2,7 +2,7 @@
 
 **League of our own** - Fantasy Football Database Architecture
 
-*Last updated: 2025-11-15*
+*Last updated: 2026-08-02*
 
 ## Overview
 
@@ -131,7 +131,7 @@ CREATE TABLE drafted_teams (
     contact_number text,
     edited_count integer DEFAULT 0,
     created_at timestamptz DEFAULT now(),
-    updated_at timestamptz DEFAULT now()
+    updated_at timestamptz
 );
 ```
 
@@ -140,7 +140,14 @@ CREATE TABLE drafted_teams (
 - `allowed_transfers`: Whether team can make player transfers
 - `total_team_value`: Calculated team value for budget validation
 - `active_season`: Season identifier (e.g., "24-25")
-- `edited_count`: Number of times team has been modified
+- `created_at`: When the team was first submitted
+- `updated_at`: When the `drafted_teams` row was last updated; remains `NULL` until the first update and is maintained by a database trigger
+- `edited_count`: Number of successful edit-link resubmissions after the original submission; it does not count every administrative or transfer change
+
+**Submission Metadata Access:**
+- Public team functions omit `created_at`, `updated_at`, and `edited_count`
+- Anonymous users do not have direct column privileges for these fields
+- Authenticated administrators can fetch the three fields for the admin-only submission history popover on the teams page
 
 **Budget Constraints:**
 - Standard teams: 90 points maximum

--- a/supabase/migrations/20260802210000_restrict_team_metadata_to_admins.sql
+++ b/supabase/migrations/20260802210000_restrict_team_metadata_to_admins.sql
@@ -1,0 +1,7 @@
+-- Authenticated users are the application's administrators. Submission history
+-- remains readable by them through the existing authenticated table grant, but
+-- must not be exposed to anonymous visitors once league data is public.
+
+revoke select (created_at, updated_at, edited_count)
+on table public.drafted_teams
+from public, anon;


### PR DESCRIPTION
## Summary

- add an admin-only submission history popover to team cards on the Teams page
- show created time, last edited time, and edit count
- fetch metadata separately for authenticated administrators and clear it on sign-out
- revoke anonymous database access to the metadata columns
- react to Supabase sessions restored after page mount

## Validation

- pnpm typecheck
- pnpm lint
- pnpm exec vitest run --pool=threads — 91 tests passed
- local Supabase migration applied and verified: anonymous access denied, authenticated access retained

This is the production promotion PR for the feature branch. The same branch was previously merged into staging as PR #47.