### PR TITLE
Enforce team submission deadline and show closed state

### DIFF
--- a/app/composables/useTeamBuilder.ts
+++ b/app/composables/useTeamBuilder.ts
@@ -12,6 +12,62 @@ interface LoadingState {
   submittingForm: boolean;
 }
 
+type UnknownError = {
+  data?: UnknownError;
+  message?: unknown;
+  response?: UnknownError;
+  status?: unknown;
+  statusCode?: unknown;
+  statusMessage?: unknown;
+};
+
+const asUnknownError = (error: unknown): UnknownError =>
+  error && typeof error === 'object' ? error as UnknownError : {};
+
+const asStatusCode = (value: unknown): number | undefined => {
+  const statusCode = typeof value === 'number' ? value : Number(value);
+  return Number.isInteger(statusCode) ? statusCode : undefined;
+};
+
+const getErrorStatusCode = (error: unknown): number | undefined => {
+  const candidate = asUnknownError(error);
+  return asStatusCode(candidate.statusCode)
+    ?? asStatusCode(candidate.status)
+    ?? asStatusCode(asUnknownError(candidate.response).status)
+    ?? asStatusCode(asUnknownError(candidate.data).statusCode);
+};
+
+const getErrorMessages = (error: unknown): string[] => {
+  const candidate = asUnknownError(error);
+  const data = asUnknownError(candidate.data);
+  return [candidate.message, candidate.statusMessage, data.message, data.statusMessage]
+    .filter((message): message is string => typeof message === 'string');
+};
+
+const isTeamRegistrationClosedError = (error: unknown): boolean => {
+  const messages = getErrorMessages(error);
+  return getErrorStatusCode(error) === 403
+    || messages.some(message => message.includes('Team registration is closed'));
+};
+
+export const getTeamSubmissionErrorAlert = (error: unknown, editing: boolean) => {
+  if (isTeamRegistrationClosedError(error)) {
+    return {
+      title: editing ? 'Team editing closed' : 'Team submissions closed',
+      description: editing
+        ? 'The submission deadline has passed, so saved teams can no longer be changed.'
+        : 'The submission deadline has passed, so new teams are no longer being accepted.',
+    };
+  }
+
+  return {
+    title: editing ? 'Unable to load team' : 'Submission failed',
+    description: editing
+      ? 'We could not load that saved team. Please check the link and try again.'
+      : 'We could not submit your team. Please try again.',
+  };
+};
+
 type DraftedPlayerFromQuery = {
   drafted_player_id: number;
   drafted_team: number | null;
@@ -115,9 +171,10 @@ export const useTeamBuilder = () => {
       draftedTeamData.value = { ...data, key: id };
       setTeamPlayers(DEFAULT_TEAM_STRUCTURE, data.players);
     }
-    catch {
-      error.value = 'Failed to fetch team data';
-      addToast('error', 'Error', 'Failed to fetch team data');
+    catch (fetchError) {
+      const alert = getTeamSubmissionErrorAlert(fetchError, true);
+      error.value = alert.description;
+      addToast('error', alert.title, alert.description);
       setTeamPlayers(DEFAULT_TEAM_STRUCTURE);
     }
     finally {
@@ -266,11 +323,9 @@ export const useTeamBuilder = () => {
         : result.outcome === 'updated' ? 'updated' : 'submitted';
     }
     catch (submissionError) {
-      const message = submissionError instanceof Error
-        ? submissionError.message
-        : 'Failed to submit team. Please try again.';
-      error.value = message;
-      addToast('error', 'Submission failed', message);
+      const alert = getTeamSubmissionErrorAlert(submissionError, isExistingDraftedTeam.value);
+      error.value = alert.description;
+      addToast('error', alert.title, alert.description);
     }
     finally {
       loading.value.submittingForm = false;

--- a/app/pages/team-builder/index.vue
+++ b/app/pages/team-builder/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { PlayerPosition } from '~/types/PlayerPosition';
+import { isTeamRegistrationOpen } from '~~/shared/utils/appSettings';
 import { SUPPORT_EMAIL } from '~~/shared/utils/contact';
 
 const {
@@ -24,6 +25,14 @@ const {
   teamRegistrationOpen: registrationOpen,
   teamSubmissionDeadline,
 } = useAppSettings();
+
+const deadlineCheckTime = ref(new Date());
+let deadlineCheckInterval: ReturnType<typeof setInterval> | undefined;
+
+const registrationIsOpen = computed(() => isTeamRegistrationOpen({
+  teamRegistrationOpen: registrationOpen.value,
+  teamSubmissionDeadline: teamSubmissionDeadline.value,
+}, deadlineCheckTime.value));
 
 const positionConfig = [
   {
@@ -99,10 +108,22 @@ const saveConfirmationAlert = computed(() => {
   }
 });
 
-if (registrationOpen.value && route.query.id) {
+onMounted(() => {
+  deadlineCheckInterval = setInterval(() => {
+    deadlineCheckTime.value = new Date();
+  }, 60_000);
+});
+
+onBeforeUnmount(() => {
+  if (deadlineCheckInterval) {
+    clearInterval(deadlineCheckInterval);
+  }
+});
+
+if (registrationIsOpen.value && route.query.id) {
   await fetchDraftedTeamData();
 }
-else if (registrationOpen.value) {
+else if (registrationIsOpen.value) {
   setTeamPlayers([
     { position: 1, count: 1 },
     { position: 2, count: 4 },
@@ -114,16 +135,20 @@ else if (registrationOpen.value) {
 
 <template>
   <div
-    v-if="!registrationOpen"
+    v-if="!registrationIsOpen"
     class="flex min-h-full items-center justify-center"
   >
     <UAlert
       color="info"
       variant="soft"
+      icon="i-lucide-lock-keyhole"
       class="max-w-xl"
     >
+      <template #title>
+        Team submissions closed
+      </template>
       <template #description>
-        Team entries are currently closed.
+        Team submissions are now closed. Teams will be available before the season begins.
       </template>
     </UAlert>
   </div>

--- a/app/tests/server/teamSubmissionService.test.ts
+++ b/app/tests/server/teamSubmissionService.test.ts
@@ -47,6 +47,7 @@ const createDependencies = (
   loadAppSettings: vi.fn().mockResolvedValue({
     activeSeason: '26-27',
     teamRegistrationOpen: true,
+    teamSubmissionDeadline: '2026-08-20',
   }),
   verifyTurnstile: vi.fn().mockResolvedValue(true),
   loadPlayers: vi.fn().mockResolvedValue(validPlayers()),
@@ -143,6 +144,7 @@ describe('processTeamSubmission', () => {
       loadAppSettings: vi.fn().mockResolvedValue({
         activeSeason: '26-27',
         teamRegistrationOpen: false,
+        teamSubmissionDeadline: '2026-08-20',
       }),
     });
 
@@ -151,6 +153,28 @@ describe('processTeamSubmission', () => {
       message: 'Team registration is closed',
     });
     expect(dependencies.loadPlayers).not.toHaveBeenCalled();
+  });
+
+  it('rejects submissions after the UK deadline even when the registration flag is still open', async () => {
+    const dependencies = createDependencies({
+      now: () => new Date('2026-08-20T23:00:00.000Z'),
+    });
+
+    await expect(processTeamSubmission(validRequest(), dependencies)).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'Team registration is closed',
+    });
+    expect(dependencies.loadPlayers).not.toHaveBeenCalled();
+  });
+
+  it('allows submissions through 23:59 UK time on the deadline date', async () => {
+    const dependencies = createDependencies({
+      now: () => new Date('2026-08-20T22:59:59.999Z'),
+    });
+
+    await expect(processTeamSubmission(validRequest(), dependencies)).resolves.toMatchObject({
+      outcome: 'created',
+    });
   });
 
   it('does not save a team when authoritative player validation fails', async () => {

--- a/app/tests/settings/appSettings.test.ts
+++ b/app/tests/settings/appSettings.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 
 import { describe, expect, it } from 'vitest';
-import { parseAppSettings } from '../../../shared/utils/appSettings';
+import {
+  isTeamRegistrationOpen,
+  isTeamSubmissionDeadlinePassed,
+  parseAppSettings,
+} from '../../../shared/utils/appSettings';
 
 describe('parseAppSettings', () => {
   it('returns typed application settings from database rows', () => {
@@ -76,5 +80,27 @@ describe('parseAppSettings', () => {
       { setting_key: 'team_registration_open', setting_value: 'true' },
       { setting_key: 'team_submission_deadline', setting_value: '20/08/2026' },
     ])).toThrow('Setting team_submission_deadline must use the YYYY-MM-DD format');
+  });
+
+  it('evaluates the submission deadline using UK calendar time', () => {
+    expect(isTeamSubmissionDeadlinePassed(
+      '2026-08-20',
+      new Date('2026-08-20T22:59:59.999Z'),
+    )).toBe(false);
+    expect(isTeamSubmissionDeadlinePassed(
+      '2026-08-20',
+      new Date('2026-08-20T23:00:00.000Z'),
+    )).toBe(true);
+  });
+
+  it('combines the manual registration flag with the deadline', () => {
+    expect(isTeamRegistrationOpen({
+      teamRegistrationOpen: true,
+      teamSubmissionDeadline: '2026-08-20',
+    }, new Date('2026-08-20T22:59:59.999Z'))).toBe(true);
+    expect(isTeamRegistrationOpen({
+      teamRegistrationOpen: false,
+      teamSubmissionDeadline: '2026-08-20',
+    }, new Date('2026-08-20T22:59:59.999Z'))).toBe(false);
   });
 });

--- a/app/tests/settings/appSettings.test.ts
+++ b/app/tests/settings/appSettings.test.ts
@@ -102,5 +102,9 @@ describe('parseAppSettings', () => {
       teamRegistrationOpen: false,
       teamSubmissionDeadline: '2026-08-20',
     }, new Date('2026-08-20T22:59:59.999Z'))).toBe(false);
+    expect(isTeamRegistrationOpen({
+      teamRegistrationOpen: true,
+      teamSubmissionDeadline: '2026-08-20',
+    }, new Date('2026-08-20T23:00:00.000Z'))).toBe(false);
   });
 });

--- a/app/tests/team-builder/composables/useTeamBuilder.test.ts
+++ b/app/tests/team-builder/composables/useTeamBuilder.test.ts
@@ -6,7 +6,10 @@ import {
   createMockTeamTableData,
   createMockTeamWithPlayers,
 } from '@/tests/factories';
-import { useTeamBuilder } from '@/composables/useTeamBuilder';
+import {
+  getTeamSubmissionErrorAlert,
+  useTeamBuilder,
+} from '@/composables/useTeamBuilder';
 import { withSetup } from '@/tests/setup';
 
 // Mock Nuxt composables used by useTeamBuilder
@@ -44,6 +47,22 @@ vi.mock('@/utils/utility', () => ({
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+describe('team submission error messages', () => {
+  it('turns a closed-submission response into a user-friendly message', () => {
+    expect(getTeamSubmissionErrorAlert({ statusCode: 403 }, false)).toEqual({
+      title: 'Team submissions closed',
+      description: 'The submission deadline has passed, so new teams are no longer being accepted.',
+    });
+  });
+
+  it('does not expose raw request details for an unexpected submission error', () => {
+    expect(getTeamSubmissionErrorAlert({ message: '[POST] "/api/team-submission": 500' }, false)).toEqual({
+      title: 'Submission failed',
+      description: 'We could not submit your team. Please try again.',
+    });
+  });
 });
 
 describe('useTeamBuilder - Budget Calculations', () => {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -171,7 +171,9 @@ application state without rebuilding or redeploying the site.
 entries are accepted. The server rejects new submissions and edits from 00:00
 on the following day in the `Europe/London` timezone. The database submission
 function applies the same rule as a final guard if a request crosses the
-deadline while being saved.
+deadline while being saved. The team-builder page applies the same check in the
+browser, refreshes it once a minute for tabs left open across the cutoff, and
+shows a closed-state message instead of the builder controls.
 
 The scheduled `public.close_team_registration_if_due()` database function sets
 both `team_registration_open` and `league_data_public` to `false` after the

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -167,6 +167,17 @@ application state without rebuilding or redeploying the site.
 | `team_registration_open` | boolean | `true` or `false` |
 | `team_submission_deadline` | date | `YYYY-MM-DD` |
 
+`team_submission_deadline` is interpreted as the final UK calendar day on which
+entries are accepted. The server rejects new submissions and edits from 00:00
+on the following day in the `Europe/London` timezone. The database submission
+function applies the same rule as a final guard if a request crosses the
+deadline while being saved.
+
+The scheduled `public.close_team_registration_if_due()` database function sets
+both `team_registration_open` and `league_data_public` to `false` after the
+deadline. Configure it as a recurring Supabase Cron job; the server-side check
+remains authoritative if the job is delayed.
+
 Postgres stores each `setting_value` as text. `parseAppSettings` is the single
 application boundary that validates and converts those strings into typed values.
 Missing or invalid values fail closed: anonymous visitors see the coming-soon page
@@ -478,4 +489,4 @@ Default includes `--host` for network access (see package.json scripts).
 
 ---
 
-**Last updated:** 2026-08-02
+**Last updated:** 2026-08-03

--- a/docs/runbooks/season-rollover.md
+++ b/docs/runbooks/season-rollover.md
@@ -1,6 +1,6 @@
 # Season rollover runbook
 
-**Last updated:** 2026-07-28
+**Last updated:** 2026-08-03
 
 Use this runbook first in staging and then in production. The SQL remains a
 deliberate manual operation because archiving and clearing operational data are
@@ -50,6 +50,25 @@ where setting_key = 'team_registration_open';
 
 Confirm the team builder no longer accepts a submission before continuing.
 Keep `league_data_public` set to `'false'` during the reveal window.
+
+## Automated deadline closure
+
+After the deadline-closure migration is deployed, enable the `pg_cron` module
+in the Supabase Dashboard and create a recurring job that runs at 00:00 and
+23:00 UTC:
+
+```sql
+select public.close_team_registration_if_due();
+```
+
+Use the schedule `0 0,23 * * *` and a descriptive job name such as
+`close-team-registration-if-due`. Supabase databases and the standard Cron
+schedule use UTC/GMT; the two daily runs mean one aligns with UK midnight in
+winter and the other aligns with UK midnight in summer. The function safely
+no-ops on the extra run. Confirm the job appears in the Cron dashboard and
+inspect its run history after a staging test. The function uses `Europe/London`
+calendar dates, while the application and database submission function reject
+late requests independently of Cron.
 
 ## 2. Archive 2025/26
 

--- a/server/api/team-submission.post.ts
+++ b/server/api/team-submission.post.ts
@@ -64,6 +64,7 @@ export default defineEventHandler(async (event) => {
         return {
           activeSeason: settings.activeSeason,
           teamRegistrationOpen: settings.teamRegistrationOpen,
+          teamSubmissionDeadline: settings.teamSubmissionDeadline,
         };
       },
       verifyTurnstile: async (token) => {
@@ -101,6 +102,10 @@ export default defineEventHandler(async (event) => {
             throw new TeamSubmissionError(409, 'Another team already uses this email address');
           }
           return { outcome: 'existing-email' };
+        }
+
+        if (error?.message.includes('Team registration is closed')) {
+          throw new TeamSubmissionError(403, 'Team registration is closed');
         }
 
         if (error && violatesConstraint(error, NAME_UNIQUE_INDEX)) {

--- a/server/api/team-submission/[key].get.ts
+++ b/server/api/team-submission/[key].get.ts
@@ -1,6 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '~/types/database.types';
-import { APP_SETTING_KEYS, parseAppSettings } from '../../../shared/utils/appSettings';
+import {
+  APP_SETTING_KEYS,
+  isTeamRegistrationOpen,
+  parseAppSettings,
+} from '../../../shared/utils/appSettings';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -36,7 +40,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 500, statusMessage: 'Application settings are invalid' });
   }
 
-  if (!settings.teamRegistrationOpen) {
+  if (!isTeamRegistrationOpen(settings)) {
     throw createError({ statusCode: 403, statusMessage: 'Team registration is closed' });
   }
 

--- a/server/utils/teamSubmissionService.ts
+++ b/server/utils/teamSubmissionService.ts
@@ -4,6 +4,7 @@ import {
   validateSubmissionPlayers,
 } from './teamSubmission';
 import type { TeamSubmissionResponse } from '../../shared/types/teamSubmission';
+import { isTeamRegistrationOpen } from '../../shared/utils/appSettings';
 
 export interface SavedTeam {
   drafted_team_id: number;
@@ -45,7 +46,9 @@ export interface TeamSubmissionDependencies {
   loadAppSettings: () => Promise<{
     activeSeason: string;
     teamRegistrationOpen: boolean;
+    teamSubmissionDeadline: string;
   }>;
+  now?: () => Date;
   verifyTurnstile: (token: string) => Promise<boolean>;
   loadPlayers: (playerIds: number[]) => Promise<SubmissionPlayer[]>;
   saveTeam: (submission: SaveTeamSubmission) => Promise<SaveTeamResult>;
@@ -84,7 +87,7 @@ export const processTeamSubmission = async (
 
   const settings = await dependencies.loadAppSettings();
 
-  if (!settings.teamRegistrationOpen) {
+  if (!isTeamRegistrationOpen(settings, dependencies.now?.())) {
     throw new TeamSubmissionError(403, 'Team registration is closed');
   }
 

--- a/shared/utils/appSettings.ts
+++ b/shared/utils/appSettings.ts
@@ -13,6 +13,8 @@ export interface AppSettings {
   teamSubmissionDeadline: string;
 }
 
+export const TEAM_SUBMISSION_TIME_ZONE = 'Europe/London';
+
 export const APP_SETTING_KEYS = [
   'active_season',
   'current_gameweek',
@@ -74,6 +76,34 @@ const parseTeamSubmissionDeadline = (value: string): string => {
 
   return value;
 };
+
+const formatDateInTimeZone = (date: Date, timeZone: string): string => {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const values = new Map(parts.map(part => [part.type, part.value]));
+
+  return `${values.get('year')}-${values.get('month')}-${values.get('day')}`;
+};
+
+/**
+ * Treats the configured date as the final day on which teams may be submitted
+ * in the league's timezone. Submissions close at 00:00 on the following UK
+ * calendar day, so the deadline remains open through 23:59:59 UK time.
+ */
+export const isTeamSubmissionDeadlinePassed = (
+  deadline: string,
+  now: Date = new Date(),
+): boolean => formatDateInTimeZone(now, TEAM_SUBMISSION_TIME_ZONE) > deadline;
+
+export const isTeamRegistrationOpen = (
+  settings: Pick<AppSettings, 'teamRegistrationOpen' | 'teamSubmissionDeadline'>,
+  now: Date = new Date(),
+): boolean => settings.teamRegistrationOpen
+  && !isTeamSubmissionDeadlinePassed(settings.teamSubmissionDeadline, now);
 
 export const parseAppSettings = (rows: AppSettingRow[]): AppSettings => {
   const values = new Map(

--- a/supabase/migrations/20260803230000_add_team_submission_deadline_closer.sql
+++ b/supabase/migrations/20260803230000_add_team_submission_deadline_closer.sql
@@ -1,0 +1,23 @@
+create or replace function public.close_team_registration_if_due()
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  update public.settings
+  set
+    setting_value = 'false',
+    updated_at = now()
+  where setting_key in ('team_registration_open', 'league_data_public')
+    and exists (
+      select 1
+      from public.settings deadline_setting
+      where deadline_setting.setting_key = 'team_submission_deadline'
+        and (now() at time zone 'Europe/London')::date > deadline_setting.setting_value::date
+    );
+end;
+$$;
+
+revoke all on function public.close_team_registration_if_due() from public, anon, authenticated;
+grant execute on function public.close_team_registration_if_due() to service_role;

--- a/supabase/migrations/20260803231000_enforce_team_submission_deadline_in_rpc.sql
+++ b/supabase/migrations/20260803231000_enforce_team_submission_deadline_in_rpc.sql
@@ -1,0 +1,112 @@
+create or replace function public.save_team_submission(
+  p_active_season text,
+  p_allow_communication boolean,
+  p_allowed_transfers boolean,
+  p_contact_number text,
+  p_edit_key uuid,
+  p_player_ids integer[],
+  p_team_email text,
+  p_team_name text,
+  p_team_owner text,
+  p_total_team_value numeric
+)
+returns public.drafted_teams
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  saved_team public.drafted_teams;
+begin
+  if exists (
+    select 1
+    from public.settings
+    where setting_key = 'team_registration_open'
+      and setting_value <> 'true'
+  ) or exists (
+    select 1
+    from public.settings
+    where setting_key = 'team_submission_deadline'
+      and (now() at time zone 'Europe/London')::date > setting_value::date
+  ) then
+    raise exception 'Team registration is closed';
+  end if;
+
+  if p_edit_key is null then
+    insert into public.drafted_teams (
+      active_season,
+      allow_communication,
+      allowed_transfers,
+      contact_number,
+      team_email,
+      team_name,
+      team_owner,
+      total_team_value
+    )
+    values (
+      p_active_season,
+      p_allow_communication,
+      p_allowed_transfers,
+      p_contact_number,
+      p_team_email,
+      p_team_name,
+      p_team_owner,
+      p_total_team_value
+    )
+    returning * into saved_team;
+  else
+    update public.drafted_teams
+    set
+      allow_communication = p_allow_communication,
+      allowed_transfers = p_allowed_transfers,
+      contact_number = p_contact_number,
+      edited_count = coalesce(edited_count, 0) + 1,
+      team_email = p_team_email,
+      team_name = p_team_name,
+      team_owner = p_team_owner,
+      total_team_value = p_total_team_value
+    where key = p_edit_key
+      and active_season = p_active_season
+    returning * into saved_team;
+
+    if saved_team.drafted_team_id is null then
+      raise exception 'No editable team found';
+    end if;
+
+    delete from public.drafted_players
+    where drafted_team = saved_team.drafted_team_id;
+  end if;
+
+  insert into public.drafted_players (drafted_team, drafted_player)
+  select saved_team.drafted_team_id, player_id
+  from unnest(p_player_ids) as player_id;
+
+  return saved_team;
+end;
+$$;
+
+revoke all on function public.save_team_submission(
+  text,
+  boolean,
+  boolean,
+  text,
+  uuid,
+  integer[],
+  text,
+  text,
+  text,
+  numeric
+) from public, anon, authenticated;
+
+grant execute on function public.save_team_submission(
+  text,
+  boolean,
+  boolean,
+  text,
+  uuid,
+  integer[],
+  text,
+  text,
+  text,
+  numeric
+) to service_role;

--- a/supabase/tests/team_submission_deadline.test.sql
+++ b/supabase/tests/team_submission_deadline.test.sql
@@ -1,0 +1,50 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+
+select plan(4);
+
+update public.settings
+set setting_value = case setting_key
+  when 'team_registration_open' then 'true'
+  when 'league_data_public' then 'true'
+  when 'team_submission_deadline' then '2026-08-01'
+end
+where setting_key in (
+  'team_registration_open',
+  'league_data_public',
+  'team_submission_deadline'
+);
+
+select lives_ok(
+  $$select public.close_team_registration_if_due()$$,
+  'the deadline closer runs successfully after the deadline'
+);
+
+select results_eq(
+  $$select setting_value from public.settings where setting_key = 'team_registration_open'$$,
+  $$values ('false'::text)$$,
+  'the deadline closer disables team registration'
+);
+
+select results_eq(
+  $$select setting_value from public.settings where setting_key = 'league_data_public'$$,
+  $$values ('false'::text)$$,
+  'the deadline closer keeps submitted teams hidden'
+);
+
+select throws_ok(
+  $$
+    select public.save_team_submission(
+      '26-27', false, false, null, null, '{}'::integer[],
+      'deadline@example.test', 'Deadline Team', 'Test Owner', 0
+    )
+  $$,
+  'P0001',
+  'Team registration is closed',
+  'the database save function rejects late submissions'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## What changed

- Enforce the team submission deadline using UK calendar time on the server and in the database RPC.
- Close team submissions and edits after the configured deadline.
- Replace raw 403/request errors with friendly user-facing messages.
- Hide the team-builder controls after the deadline and show:
  "Team submissions are now closed. Teams will be available before the season begins."
- Refresh the browser-side deadline check once per minute for tabs left open across the cutoff.
- Keep the scheduled database closer for synchronising `team_registration_open` and `league_data_public`.

## Why

The deadline must be enforced server-side, while the team-builder should give users a clear explanation instead of exposing transport errors or leaving editable controls visible.

## Validation

- 19 test files passed
- 97 tests passed
- Lint passed
- Typecheck passed
- Production build passed